### PR TITLE
Add policies examples for Windows, Mac and Linux

### DIFF
--- a/docs/policy_examples/com.google.Chrome.plist
+++ b/docs/policy_examples/com.google.Chrome.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>HomepageLocation</key>
+  <string>https://www.google.com</string>
+  <key>HomepageIsNewTabPage</key>
+  <false/>
+  <key>DefaultBrowserSettingEnabled</key>
+  <true/>
+  <key>RestoreOnStartup</key>
+  <integer>1</integer>
+  <key>ManagedBookmarks</key>
+  <array>
+    <dict>
+      <key>toplevel_name</key>
+      <string>Managed bookmarks folder</string>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Google</string>
+      <key>url</key>
+      <string>google.com</string>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Youtube</string>
+      <key>url</key>
+      <string>youtube.com</string>
+    </dict>
+    <dict>
+      <key>children</key>
+      <array>
+        <dict>
+          <key>name</key>
+          <string>Chromium</string>
+          <key>url</key>
+          <string>chromium.org</string>
+        </dict>
+        <dict>
+          <key>name</key>
+          <string>Chromium Developers</string>
+          <key>url</key>
+          <string>dev.chromium.org</string>
+        </dict>
+      </array>
+      <key>name</key>
+      <string>Chrome links</string>
+    </dict>
+  </array>
+  <key>MaxConnectionsPerProxy</key>
+  <integer>99</integer>
+  <key>SafeBrowsingProtectionLevel</key>
+  <integer>1</integer>
+  <key>ExtensionInstallForcelist</key>
+  <array>
+    <string>noondiphcddnnabmjcihcjfbhfklnnep</string>
+    <string>djflhoibgkdhkhhcedjiklpkjnoahfmg</string>
+  </array>
+  <key>MetricsReportingEnabled</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/policy_examples/managed_policies.json
+++ b/docs/policy_examples/managed_policies.json
@@ -1,0 +1,38 @@
+{
+  "HomepageLocation": "https://www.google.com",
+  "HomepageIsNewTabPage": false,
+  "DefaultBrowserSettingEnabled": true,
+  "RestoreOnStartup": 1,
+  "SafeBrowsingProtectionLevel": 1,
+  "MaxConnectionsPerProxy": 99,
+  "ExtensionInstallForcelist": [
+    "noondiphcddnnabmjcihcjfbhfklnnep",
+    "djflhoibgkdhkhhcedjiklpkjnoahfmg"
+  ],
+  "ManagedBookmarks": [
+    {
+      "toplevel_name": "My managed bookmarks folder"
+    },
+    {
+      "name": "Google",
+      "url": "google.com"
+    },
+    {
+      "name": "Youtube",
+      "url": "youtube.com"
+    },
+    {
+      "children": [
+        {
+          "name": "Chromium",
+          "url": "chromium.org"
+        },
+        {
+          "name": "Chromium Developers",
+          "url": "dev.chromium.org"
+        }
+      ],
+      "name": "Chrome links"
+    }
+  ]
+}

--- a/docs/policy_examples/policies.reg
+++ b/docs/policy_examples/policies.reg
@@ -1,0 +1,19 @@
+Windows Registry Editor Version 5.00
+; chrome version: 112.0.5615.138
+
+[HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome]
+"HomepageLocation"="https://www.google.com"
+"HomepageIsNewTabPage"=dword:00000001
+"RestoreOnStartup"=dword:00000001
+"SafeBrowsingProtectionLevel"=dword:00000001
+"MaxConnectionsPerProxy"=dword:00000099
+"ManagedBookmarks"="[{\"toplevel_name\": \"Managedbookmarksfolder\"},{\"name\": \"Google\",\"url\": \"google.com\"},{\"name\": \"Youtube\",\"url\": \"youtube.com\"},{\"children\": [{\"name\": \"Chromium\",\"url\": \"chromium.org\"},{\"name\": \"ChromiumDevelopers\",\"url\": \"dev.chromium.org\"}],\"name\": \"Chromelinks\"}]"
+
+
+[HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome\ExtensionInstallForcelist]
+"1"="noondiphcddnnabmjcihcjfbhfklnnep"
+"2"="djflhoibgkdhkhhcedjiklpkjnoahfmg"
+
+
+[HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome\Recommended]
+"MetricsReportingEnabled"=dword:00000001

--- a/docs/policy_examples/recommended_policies.json
+++ b/docs/policy_examples/recommended_policies.json
@@ -1,0 +1,3 @@
+{
+  "MetricsReportingEnabled": true
+}


### PR DESCRIPTION
All examples are created based on the plist from Chrome enterprise bundle with a few tweaks:
* `DefaultBrowserSettingEnabled` is removed on Windows due to lack of supporting on Win10+
* `SafeBrowsingEnabled` is replaced with `SafeBrowsingProtectionLevel`. 
* `ExtensionInstallForcelist` update urls are removed as they are not necessary.
* `EnableMemoryInfo` and `AllowOutdatedPlugins` are removed because policies are no longer supported.
* `MetricsReportingEnabled` is used as an example of recommended policy except on Mac which can't set recommended policies with configuration file directly.