### PR TITLE
Add initial_preferences example

### DIFF
--- a/docs/policy_examples/initial_preferences
+++ b/docs/policy_examples/initial_preferences
@@ -1,0 +1,23 @@
+{
+  "sync_promo": {
+    "show_on_first_run_allowed": false
+  },
+  "distribution": {
+    "import_bookmarks_from_file": "bookmarks.html",
+    "import_bookmarks": true,
+    "ping_delay": 60,
+    "suppress_first_run_bubble": true,
+    "do_not_create_desktop_shortcut": true,
+    "do_not_create_quick_launch_shortcut": true,
+    "do_not_launch_chrome": true,
+    "do_not_register_for_update_launch": true,
+    "suppress_first_run_default_browser_prompt": true,
+    "system_level": true,
+    "verbose_logging": true
+  },
+  "first_run_tabs": [
+    "http://www.example.com",
+    "http://welcome_page",
+    "http://new_tab_page"
+  ]
+}


### PR DESCRIPTION
Initial preferences that copied from enterprise bundle, remove a few preferences that can be controlled by recommended policies already.