### PR TITLE
feat(pocket-cep): switch default to user_oauth mode and dynamically resolve MCP scopes

### DIFF
--- a/mcp-examples/pocket-cep/.dockerignore
+++ b/mcp-examples/pocket-cep/.dockerignore
@@ -1,0 +1,8 @@
+Dockerfile
+.dockerignore
+node_modules
+.next
+.git
+.env.local
+scratch
+*.log

--- a/mcp-examples/pocket-cep/.env
+++ b/mcp-examples/pocket-cep/.env
@@ -25,7 +25,7 @@
 #     MCP server, which uses it for every Google API call. This means the user
 #     must be a Google Workspace admin with the right permissions.
 #
-AUTH_MODE=service_account
+AUTH_MODE=user_oauth
 
 
 

--- a/mcp-examples/pocket-cep/Dockerfile
+++ b/mcp-examples/pocket-cep/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS base
+WORKDIR /app
+
+# 1. Install dependencies
+FROM base AS deps
+COPY package.json package-lock.json* ./
+COPY scripts ./scripts
+RUN npm install --no-audit --no-fund
+
+# 2. Build Next.js application
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NODE_ENV=production
+RUN npm run build
+
+# 3. Production runner
+FROM base AS runner
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/mcp-examples/pocket-cep/README.md
+++ b/mcp-examples/pocket-cep/README.md
@@ -78,7 +78,26 @@ Prefer manual setup? Copy `.env.local.example` to `.env.local`, fill in your sec
 
 Service-account mode (`AUTH_MODE=service_account`, default) requires a Service Account with Domain-Wide Delegation (DWD):
 
-*   **Domain-Wide Delegation JSON Key**: Upload your Service Account JSON key and set your Impersonated Admin User email in the web application by clicking the **"SA Settings"** button in the top-right header (or by manually navigating to the `/sa-setup` route on your running port). You can also configure this by setting `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json` or `CEP_SERVICE_ACCOUNT_KEY_JSON` in `.env.local`. For the 4-step Google Workspace Admin Console setup and OAuth scope allowlist, see the [MCP Server DWD Guide](https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/configuration.md#service-account--domain-wide-delegation-dwd).
+By default, Pocket CEP runs in `user_oauth` mode. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `.env.local`, then sign in with a Google Workspace admin account at http://localhost:3000.
+
+If you prefer `service_account` mode for local demos or headless execution, set `AUTH_MODE=service_account` in `.env.local`. In service-account mode, two authentication options are supported:
+
+*   **Option A (Domain-Wide Delegation JSON Key — Recommended)**: Upload your Service Account JSON key and set your Impersonated Admin User email in the web application by clicking the **"SA Settings"** button in the top-right header (or by manually navigating to the `/sa-setup` route on your running port). You can also configure this by setting `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json` or `CEP_SERVICE_ACCOUNT_KEY_JSON` in `.env.local`. For the 4-step Google Workspace Admin Console setup and OAuth scope allowlist, see the [MCP Server DWD Guide](https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/configuration.md#service-account--domain-wide-delegation-dwd).
+*   **Option B (gcloud ADC)**: Run `gcloud auth application-default login` with admin scopes:
+
+```bash
+gcloud auth application-default login --scopes="https://www.googleapis.com/auth/chrome.management.policy,https://www.googleapis.com/auth/chrome.management.reports.readonly,https://www.googleapis.com/auth/chrome.management.profiles.readonly,https://www.googleapis.com/auth/admin.reports.audit.readonly,https://www.googleapis.com/auth/admin.reports.usage.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/admin.directory.orgunit.readonly,https://www.googleapis.com/auth/admin.directory.customer.readonly,https://www.googleapis.com/auth/cloud-identity.policies,https://www.googleapis.com/auth/apps.licensing,https://www.googleapis.com/auth/cloud-platform"
+```
+
+Then pin a quota project:
+
+```bash
+gcloud auth application-default set-quota-project YOUR_PROJECT_ID
+```
+
+If the dev server starts but env vars are missing, the landing page shows
+a setup-required screen pointing back at `npm run setup`.
+Open http://localhost:3000 and sign in with Google.
 
 ---
 

--- a/mcp-examples/pocket-cep/package-lock.json
+++ b/mcp-examples/pocket-cep/package-lock.json
@@ -219,6 +219,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -427,6 +428,7 @@
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.9.tgz",
       "integrity": "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
@@ -538,6 +540,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
       "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^2.0.1"
       }
@@ -545,7 +548,8 @@
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@clack/core": {
       "version": "1.2.0",
@@ -615,26 +619,6 @@
       "dev": true,
       "dependencies": {
         "fast-string-width": "^1.1.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2126,6 +2110,7 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -2744,6 +2729,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2752,6 +2738,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2812,6 +2799,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3399,6 +3387,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3904,6 +3893,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
       "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
@@ -3993,6 +3983,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4828,6 +4819,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4963,6 +4955,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5090,6 +5083,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5392,6 +5386,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6064,6 +6059,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6692,6 +6688,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -6834,6 +6831,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
       "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -8137,6 +8135,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -8175,6 +8174,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -8703,6 +8703,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8905,6 +8906,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8913,6 +8915,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9994,6 +9997,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "devOptional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10240,6 +10244,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10504,6 +10509,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10607,6 +10613,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -10915,6 +10922,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mcp-examples/pocket-cep/package-lock.json
+++ b/mcp-examples/pocket-cep/package-lock.json
@@ -622,10 +622,11 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2329,6 +2330,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/mcp-examples/pocket-cep/scripts/setup.ts
+++ b/mcp-examples/pocket-cep/scripts/setup.ts
@@ -132,17 +132,17 @@ async function chooseAuthMode(current: string | undefined) {
   return ask<"service_account" | "user_oauth">(
     p.select({
       message: "How does Pocket CEP talk to Google APIs?",
-      initialValue: current === "user_oauth" ? "user_oauth" : "service_account",
+      initialValue: current === "service_account" ? "service_account" : "user_oauth",
       options: [
         {
-          label: "Service account (recommended for local demos)",
-          value: "service_account",
-          hint: "Uses `gcloud auth application-default login`. No user sign-in; shared identity.",
-        },
-        {
-          label: "User OAuth (per-user attribution)",
+          label: "User OAuth (recommended — per-user attribution)",
           value: "user_oauth",
           hint: "Users sign in with Google. Their token is forwarded to the MCP server.",
+        },
+        {
+          label: "Service account (local ADC demo fallback)",
+          value: "service_account",
+          hint: "Uses machine ADC credentials. No user sign-in; shared identity.",
         },
       ],
     }),

--- a/mcp-examples/pocket-cep/src/__tests__/unit/env.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/env.test.ts
@@ -82,13 +82,17 @@ describe("serverSchema", () => {
     }
   });
 
-  it("rejects user_oauth without valid Google Client ID", () => {
-    expect(serverSchema.safeParse({ ...VALID_GEMINI_OAUTH, GOOGLE_CLIENT_ID: "" }).success).toBe(
-      false,
-    );
-    expect(
-      serverSchema.safeParse({ ...VALID_GEMINI_OAUTH, GOOGLE_CLIENT_ID: "not-valid" }).success,
-    ).toBe(false);
+  it("falls back to service_account if user_oauth is configured with empty Google Client ID", () => {
+    const result = serverSchema.safeParse({ ...VALID_GEMINI_OAUTH, GOOGLE_CLIENT_ID: "" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.AUTH_MODE).toBe("service_account");
+    }
+  });
+
+  it("rejects invalid Google Client ID format", () => {
+    const result = serverSchema.safeParse({ ...VALID_GEMINI_OAUTH, GOOGLE_CLIENT_ID: "not-valid" });
+    expect(result.success).toBe(false);
   });
 
   it("accepts claude without ANTHROPIC_API_KEY (BYOK supplies the key at request time)", () => {
@@ -107,8 +111,15 @@ describe("serverSchema", () => {
     }
   });
 
-  it("rejects invalid enum values", () => {
-    expect(serverSchema.safeParse({ ...VALID_CLAUDE_SA, AUTH_MODE: "magic" }).success).toBe(false);
+  it("falls back to service_account for invalid AUTH_MODE values", () => {
+    const result = serverSchema.safeParse({ ...VALID_CLAUDE_SA, AUTH_MODE: "magic" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.AUTH_MODE).toBe("service_account");
+    }
+  });
+
+  it("rejects invalid LLM_PROVIDER values", () => {
     expect(serverSchema.safeParse({ ...VALID_CLAUDE_SA, LLM_PROVIDER: "gpt4" }).success).toBe(
       false,
     );

--- a/mcp-examples/pocket-cep/src/__tests__/unit/mcp-client.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/mcp-client.test.ts
@@ -76,6 +76,21 @@ describe("callMcpTool", () => {
     expect(options.requestInit.headers["Authorization"]).toBeUndefined();
   });
 
+  it("passes abort signal to transport when provided", async () => {
+    const controller = new AbortController();
+    await callMcpTool(
+      "http://localhost:3000/mcp",
+      "get_customer_id",
+      {},
+      undefined,
+      controller.signal,
+    );
+
+    const transportCall = vi.mocked(StreamableHTTPClientTransport).mock.calls[0];
+    const options = transportCall[1] as { requestInit: { signal: AbortSignal } };
+    expect(options.requestInit.signal).toBe(controller.signal);
+  });
+
   it("captures rawRequest and rawResponse for the inspector panel", async () => {
     const result = await callMcpTool("http://localhost:3000/mcp", "list_dlp_rules", {
       filter: "active",

--- a/mcp-examples/pocket-cep/src/app/api/auth/[...all]/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/auth/[...all]/route.ts
@@ -46,7 +46,9 @@ export async function POST(request: NextRequest) {
       if (targetUrl && typeof targetUrl === "string") {
         const u = new URL(targetUrl);
         const redirectUri = u.searchParams.get("redirect_uri");
-        console.log(`[auth] Initiating Google OAuth flow. Exact redirect_uri sent to Google: "${redirectUri}"`);
+        console.log(
+          `[auth] Initiating Google OAuth flow. Exact redirect_uri sent to Google: "${redirectUri}"`,
+        );
       }
     } catch (err) {
       console.warn("[auth] Failed to log redirect_uri:", err);

--- a/mcp-examples/pocket-cep/src/app/api/auth/[...all]/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/auth/[...all]/route.ts
@@ -22,12 +22,19 @@
  * callback route here.
  */
 
+import { type NextRequest } from "next/server";
 import { getAuth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
 
 /**
- * Delegates all /api/auth/* requests to BetterAuth. The `toNextJsHandler`
- * adapter converts BetterAuth's generic handler into Next.js App Router
- * GET/POST exports.
+ * Delegates all /api/auth/* requests to BetterAuth.
  */
-export const { GET, POST } = toNextJsHandler(getAuth());
+export async function GET(request: NextRequest) {
+  const auth = await getAuth();
+  return toNextJsHandler(auth).GET(request);
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await getAuth();
+  return toNextJsHandler(auth).POST(request);
+}

--- a/mcp-examples/pocket-cep/src/app/api/auth/[...all]/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/auth/[...all]/route.ts
@@ -36,5 +36,22 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const auth = await getAuth();
-  return toNextJsHandler(auth).POST(request);
+  const res = await toNextJsHandler(auth).POST(request);
+
+  if (request.nextUrl.pathname.includes("/sign-in/social")) {
+    try {
+      const clone = res.clone();
+      const data = await clone.json().catch(() => null);
+      const targetUrl = data?.url || clone.headers.get("location");
+      if (targetUrl && typeof targetUrl === "string") {
+        const u = new URL(targetUrl);
+        const redirectUri = u.searchParams.get("redirect_uri");
+        console.log(`[auth] Initiating Google OAuth flow. Exact redirect_uri sent to Google: "${redirectUri}"`);
+      }
+    } catch (err) {
+      console.warn("[auth] Failed to log redirect_uri:", err);
+    }
+  }
+
+  return res;
 }

--- a/mcp-examples/pocket-cep/src/app/api/auth/health/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/auth/health/route.ts
@@ -17,8 +17,7 @@ import { requireSession } from "@/lib/session";
 import { getErrorMessage } from "@/lib/errors";
 
 /**
- * Probes ADC by requesting a fresh access token. Returns 200 if Google
- * issues one and 401 with the structured payload if it refuses.
+ * Probes Google credentials by checking the user's OAuth token or ADC.
  */
 export async function GET() {
   if (!(await requireSession())) {

--- a/mcp-examples/pocket-cep/src/app/dashboard/page.tsx
+++ b/mcp-examples/pocket-cep/src/app/dashboard/page.tsx
@@ -12,8 +12,11 @@
  * error on the next user-driven fetch (e.g. the user-search call).
  */
 
+import { redirect } from "next/navigation";
 import { DashboardClient } from "./dashboard-client";
 import { getActivitySafe } from "@/lib/activity-data";
+import { getGoogleAccessToken } from "@/lib/access-token";
+import { getEnv } from "@/lib/env";
 
 /**
  * Per-user data — never pre-render at build time. Without this, Next
@@ -24,6 +27,13 @@ import { getActivitySafe } from "@/lib/activity-data";
 export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
+  const config = getEnv();
+  if (config.AUTH_MODE === "user_oauth") {
+    const token = await getGoogleAccessToken();
+    if (!token) {
+      redirect("/");
+    }
+  }
   const initialActivity = await getActivitySafe();
   return <DashboardClient initialActivity={initialActivity} />;
 }

--- a/mcp-examples/pocket-cep/src/app/page.tsx
+++ b/mcp-examples/pocket-cep/src/app/page.tsx
@@ -30,23 +30,48 @@ export default async function LandingPage() {
   }
 
   return (
-    <div className="bg-surface-dim flex flex-1 flex-col items-center justify-center overflow-y-auto px-4 py-8">
-      <main className="bg-surface ring-on-surface/10 my-auto flex w-full max-w-[400px] flex-col items-center gap-6 rounded-[var(--radius-md)] px-10 py-10 shadow-[var(--shadow-elevation-1)] ring-1">
-        <div className="flex flex-col items-center gap-2">
-          <Shield className="text-primary size-8" aria-hidden="true" />
-          <h1 className="text-on-surface text-[1.375rem] font-medium text-balance">Pocket CEP</h1>
+    <div className="bg-surface-dim flex flex-1 items-center justify-center px-4">
+      <main className="bg-surface ring-on-surface/10 flex w-full max-w-[440px] flex-col items-center gap-6 rounded-[var(--radius-md)] px-8 py-10 shadow-[var(--shadow-elevation-1)] ring-1">
+        <div className="flex flex-col items-center gap-1 text-center">
+          <div className="bg-primary/10 text-primary mb-1 flex size-12 items-center justify-center rounded-full">
+            <Shield className="size-6" aria-hidden="true" />
+          </div>
+          <h1 className="text-on-surface text-xl font-semibold tracking-tight">Pocket CEP</h1>
+          <p className="text-on-surface-variant text-xs font-medium tracking-wider uppercase">
+            Chrome Enterprise Premium
+          </p>
         </div>
 
-        <p className="text-on-surface-variant text-center text-pretty">
-          An educational companion for the Chrome Enterprise Premium MCP server. Investigate user
-          activity and chat with an AI agent.
-        </p>
+        <div className="text-on-surface-variant flex w-full flex-col gap-3 text-sm">
+          <p className="text-center font-normal text-pretty">
+            Your AI-powered administrative command center. Sign in to get started:
+          </p>
+          <ul className="text-on-surface/85 flex flex-col gap-2 rounded-lg bg-black/5 p-3.5 text-xs dark:bg-white/5">
+            <li className="flex items-center gap-2.5">
+              <span className="bg-primary flex size-1.5 shrink-0 rounded-full" />
+              <span>
+                <strong>Investigate</strong> user audit activity logs & telemetry
+              </span>
+            </li>
+            <li className="flex items-center gap-2.5">
+              <span className="bg-primary flex size-1.5 shrink-0 rounded-full" />
+              <span>
+                <strong>Learn</strong> about new Chrome security features
+              </span>
+            </li>
+            <li className="flex items-center gap-2.5">
+              <span className="bg-primary flex size-1.5 shrink-0 rounded-full" />
+              <span>
+                <strong>Manage</strong> your existing security controls & DLP rules
+              </span>
+            </li>
+          </ul>
+        </div>
 
         <SignInButton />
 
-        <p className="text-on-surface-muted text-center text-sm text-pretty">
-          Sign in with your Google Workspace account. Your credentials authenticate with the MCP
-          server.
+        <p className="text-on-surface-muted text-center text-xs text-pretty">
+          Sign in with your Google Workspace admin account to authenticate against the MCP server.
         </p>
       </main>
 

--- a/mcp-examples/pocket-cep/src/components/auth-banner.tsx
+++ b/mcp-examples/pocket-cep/src/components/auth-banner.tsx
@@ -19,6 +19,7 @@ import { ShieldAlert, Copy, Check, RefreshCw } from "lucide-react";
 import { useAuthHealth } from "@/components/auth-health-provider";
 import Link from "next/link";
 import { isAuthErrorPayload } from "@/lib/auth-errors";
+import { authClient } from "@/lib/auth-client";
 
 function renderRemedyText(remedy: string) {
   const markdownMatch = remedy.match(/\[([^\]]+)\]\(([^)]+)\)/);
@@ -69,8 +70,22 @@ export function AuthBanner() {
   const { error, report, clear } = useAuthHealth();
   const [copied, setCopied] = useState(false);
   const [checking, setChecking] = useState(false);
+  const [signingIn, setSigningIn] = useState(false);
 
   if (!error) return null;
+
+  async function handleSignIn() {
+    setSigningIn(true);
+    try {
+      await authClient.signIn.social({
+        provider: "google",
+        callbackURL: window.location.pathname || "/dashboard",
+      });
+    } catch (err) {
+      console.error("Sign-in redirect failed:", err);
+      setSigningIn(false);
+    }
+  }
 
   async function handleCheckAgain() {
     setChecking(true);
@@ -111,27 +126,56 @@ export function AuthBanner() {
         <p className="text-on-surface-variant text-pretty">{error.message}</p>
       </div>
 
-      {error.command && (
+      {!error.command ? (
         <button
           type="button"
-          onClick={handleCopy}
-          className="state-layer ring-warning/30 inline-flex items-center gap-1.5 rounded-[var(--radius-xs)] bg-white/50 px-2 py-1 font-mono text-xs ring-1"
-          aria-label={`Copy command: ${error.command}`}
+          onClick={handleSignIn}
+          disabled={signingIn}
+          className="state-layer ring-warning/30 bg-surface text-on-surface inline-flex items-center gap-2 rounded-[var(--radius-xs)] px-2.5 py-1 text-xs font-medium shadow-sm ring-1 disabled:opacity-50"
         >
-          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
-          <span>{error.command}</span>
+          <svg viewBox="0 0 24 24" className="size-3.5 shrink-0" aria-hidden="true">
+            <path
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+              fill="#4285F4"
+            />
+            <path
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              fill="#34A853"
+            />
+            <path
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              fill="#EA4335"
+            />
+          </svg>
+          <span>{signingIn ? "Redirecting…" : "Sign in with Google"}</span>
         </button>
-      )}
+      ) : (
+        <>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="state-layer ring-warning/30 inline-flex items-center gap-1.5 rounded-[var(--radius-xs)] bg-white/50 px-2 py-1 font-mono text-xs ring-1"
+            aria-label={`Copy command: ${error.command}`}
+          >
+            {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+            <span>{error.command}</span>
+          </button>
 
-      <button
-        type="button"
-        onClick={handleCheckAgain}
-        disabled={checking}
-        className="state-layer ring-warning/30 inline-flex items-center gap-1.5 rounded-[var(--radius-xs)] px-2 py-1 text-xs font-medium ring-1 disabled:opacity-50"
-      >
-        <RefreshCw className={checking ? "size-3 animate-spin" : "size-3"} aria-hidden="true" />
-        {checking ? "Checking…" : "Check again"}
-      </button>
+          <button
+            type="button"
+            onClick={handleCheckAgain}
+            disabled={checking}
+            className="state-layer ring-warning/30 inline-flex items-center gap-1.5 rounded-[var(--radius-xs)] px-2 py-1 text-xs font-medium ring-1 disabled:opacity-50"
+          >
+            <RefreshCw className={checking ? "size-3 animate-spin" : "size-3"} aria-hidden="true" />
+            {checking ? "Checking…" : "Check again"}
+          </button>
+        </>
+      )}
 
       {error.docsUrl && (
         <a

--- a/mcp-examples/pocket-cep/src/lib/access-token.ts
+++ b/mcp-examples/pocket-cep/src/lib/access-token.ts
@@ -282,6 +282,13 @@ export async function getGoogleAccessToken(options?: {
       "accessToken" in tokenResult &&
       typeof tokenResult.accessToken === "string"
     ) {
+      if ("accessTokenExpiresAt" in tokenResult && tokenResult.accessTokenExpiresAt) {
+        const expiresAt = new Date(tokenResult.accessTokenExpiresAt as string | number | Date);
+        if (!isNaN(expiresAt.getTime()) && expiresAt.getTime() < Date.now()) {
+          console.warn(LOG_TAGS.AUTH, "Google OAuth access token expired at:", expiresAt);
+          return undefined;
+        }
+      }
       return tokenResult.accessToken;
     }
 

--- a/mcp-examples/pocket-cep/src/lib/access-token.ts
+++ b/mcp-examples/pocket-cep/src/lib/access-token.ts
@@ -264,7 +264,13 @@ export async function getGoogleAccessToken(options?: {
   }
 
   try {
-    const auth = getAuth();
+    const auth = await getAuth();
+    /**
+     * BetterAuth's getAccessToken reads the session cookie (via headers()),
+     * looks up the stored Google OAuth token, and returns it. The
+     * `providerId: "google"` tells BetterAuth which social provider's
+     * token we want.
+     */
     const tokenResult = await auth.api.getAccessToken({
       body: { providerId: "google" },
       headers: await headers(),

--- a/mcp-examples/pocket-cep/src/lib/admin-sdk.ts
+++ b/mcp-examples/pocket-cep/src/lib/admin-sdk.ts
@@ -7,6 +7,7 @@ import { LOG_TAGS } from "./constants";
 import { buildGoogleApiHeaders } from "./access-token";
 import { AuthError, isAuthError, toAuthError } from "./auth-errors";
 import { getActiveCustomerId } from "./sa-session";
+import { getEnv } from "./env";
 
 /**
  * Converts a user-typed search string into Admin SDK query syntax.
@@ -29,21 +30,21 @@ export type DirectoryUser = {
 
 /**
  * Searches the Google Workspace user directory via the Admin SDK REST API.
- *
- * Throws `AuthError` on credential failure so API routes can return a
- * structured 401. Non-auth failures return an empty array (existing
- * behavior) — they're logged but treated as "no results".
- *
- * Supports Admin SDK query syntax:
- *   - "email:alice*" for email prefix
- *   - Plain text for general name/email search
- *   - Empty string returns the first page of all users
  */
 export async function searchUsers(
   query: string,
   accessToken?: string,
   maxResults = 20,
 ): Promise<DirectoryUser[]> {
+  if (getEnv().AUTH_MODE === "user_oauth" && !accessToken) {
+    throw new AuthError({
+      code: "unauthenticated",
+      source: "admin-sdk",
+      message: "Your Google OAuth session is missing or expired.",
+      remedy: "Sign out and sign back in with Google to refresh your credentials.",
+    });
+  }
+
   const customerId = await getActiveCustomerId();
   const params = new URLSearchParams({
     customer: customerId || "my_customer",

--- a/mcp-examples/pocket-cep/src/lib/auth-errors.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth-errors.ts
@@ -172,8 +172,6 @@ function extractMessage(err: unknown): string {
   return "";
 }
 
-import { getEnv } from "./env";
-
 function buildPayload(
   code: AuthErrorCode,
   source: AuthErrorPayload["source"],
@@ -191,7 +189,6 @@ function buildPayload(
   }
 
   const isSaMode = authMode === "service_account";
-  const isOauthMode = authMode === "user_oauth";
   switch (code) {
     case "dwd_scope_mismatch": {
       const missingText = dwdDiagnostics?.missingScopes?.length

--- a/mcp-examples/pocket-cep/src/lib/auth-errors.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth-errors.ts
@@ -172,6 +172,8 @@ function extractMessage(err: unknown): string {
   return "";
 }
 
+import { getEnv } from "./env";
+
 function buildPayload(
   code: AuthErrorCode,
   source: AuthErrorPayload["source"],
@@ -190,7 +192,6 @@ function buildPayload(
 
   const isSaMode = authMode === "service_account";
   const isOauthMode = authMode === "user_oauth";
-
   switch (code) {
     case "dwd_scope_mismatch": {
       const missingText = dwdDiagnostics?.missingScopes?.length

--- a/mcp-examples/pocket-cep/src/lib/auth.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth.ts
@@ -45,7 +45,8 @@ const FALLBACK_ADMIN_SCOPES = [
  */
 async function resolveAdminScopes(mcpUrl: string): Promise<string[]> {
   try {
-    const res = await callMcpTool(mcpUrl, "cep_auth", { authMethod: "manual" });
+    const signal = AbortSignal.timeout(2500);
+    const res = await callMcpTool(mcpUrl, "cep_auth", { authMethod: "manual" }, undefined, signal);
     const text = typeof res.content === "string" ? res.content : JSON.stringify(res.content);
     const match = text.match(/https:\/\/accounts\.google\.com[^\s"']+/);
     if (match) {
@@ -67,7 +68,10 @@ async function resolveAdminScopes(mcpUrl: string): Promise<string[]> {
       }
     }
   } catch (err) {
-    console.warn("[auth] Could not fetch dynamic scopes from MCP cep_auth tool, using fallback scopes:", err);
+    console.warn(
+      "[auth] Could not fetch dynamic scopes from MCP cep_auth tool, using fallback scopes:",
+      err,
+    );
   }
   return FALLBACK_ADMIN_SCOPES;
 }

--- a/mcp-examples/pocket-cep/src/lib/auth.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth.ts
@@ -18,32 +18,55 @@ import { nextCookies } from "better-auth/next-js";
 import { getEnv } from "./env";
 import { SA_EMAIL_DOMAIN } from "./constants";
 
+import { callMcpTool } from "./mcp-client";
+
 /**
- * Google Workspace admin scopes requested during the OAuth consent flow.
- * These are broad because the MCP server needs them to call various
- * Chrome Enterprise and Admin SDK APIs on behalf of the signed-in admin.
- * The scopes here must match what the Google Cloud OAuth consent screen
- * has been configured to allow.
+ * Fallback Google Workspace admin scopes if MCP dynamic discovery fails.
  */
-const ADMIN_SCOPES = [
+const FALLBACK_ADMIN_SCOPES = [
   "openid",
-  "email",
+  "https://www.googleapis.com/auth/userinfo.email",
   "profile",
-  "https://www.googleapis.com/auth/admin.reports.audit.readonly",
+  "https://www.googleapis.com/auth/chrome.management.policy",
   "https://www.googleapis.com/auth/chrome.management.reports.readonly",
   "https://www.googleapis.com/auth/chrome.management.profiles.readonly",
+  "https://www.googleapis.com/auth/admin.reports.audit.readonly",
   "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
   "https://www.googleapis.com/auth/admin.directory.customer.readonly",
-  "https://www.googleapis.com/auth/cloud-identity.policies",
   "https://www.googleapis.com/auth/apps.licensing",
-  "https://www.googleapis.com/auth/cloud-platform",
+  "https://www.googleapis.com/auth/cloud-identity.policies",
+  "https://www.googleapis.com/auth/service.management",
 ];
 
 /**
- * Builds the BetterAuth instance based on the current AUTH_MODE.
- * Kept as a factory function so env is read lazily (not at import time).
+ * Dynamically retrieves requested OAuth scopes by calling the MCP server's
+ * `cep_auth` tool in `manual` mode and parsing the generated consent URL.
  */
-function createAuth() {
+async function resolveAdminScopes(mcpUrl: string): Promise<string[]> {
+  try {
+    const res = await callMcpTool(mcpUrl, "cep_auth", { authMethod: "manual" });
+    const text = typeof res.content === "string" ? res.content : JSON.stringify(res.content);
+    const match = text.match(/https:\/\/accounts\.google\.com[^\s"']+/);
+    if (match) {
+      const url = new URL(match[0]);
+      const scopeParam = url.searchParams.get("scope");
+      if (scopeParam) {
+        const dynamicScopes = decodeURIComponent(scopeParam).split(/[\s+]/).filter(Boolean);
+        if (dynamicScopes.length > 0) {
+          return Array.from(new Set(["openid", "email", "profile", ...dynamicScopes]));
+        }
+      }
+    }
+  } catch (err) {
+    console.warn("[auth] Could not fetch dynamic scopes from MCP cep_auth tool, using fallback scopes:", err);
+  }
+  return FALLBACK_ADMIN_SCOPES;
+}
+
+/**
+ * Builds the BetterAuth instance based on the current AUTH_MODE and scopes.
+ */
+function createAuth(scopes: string[]) {
   const config = getEnv();
   const isSA = config.AUTH_MODE === "service_account";
 
@@ -61,7 +84,7 @@ function createAuth() {
           google: {
             clientId: config.GOOGLE_CLIENT_ID,
             clientSecret: config.GOOGLE_CLIENT_SECRET,
-            scope: ADMIN_SCOPES,
+            scope: scopes,
           },
         },
 
@@ -76,16 +99,19 @@ function createAuth() {
 }
 
 /** Singleton — BetterAuth is configured once per process lifetime. */
-let _auth: ReturnType<typeof createAuth> | null = null;
+let _authPromise: Promise<ReturnType<typeof createAuth>> | null = null;
 
 /**
- * Returns the lazily-initialized BetterAuth instance. Called by API route
- * handlers (for auth endpoints) and by access-token.ts (to retrieve the
- * Google OAuth token in user_oauth mode).
+ * Returns the lazily-initialized async BetterAuth instance.
  */
-export function getAuth() {
-  if (!_auth) {
-    _auth = createAuth();
+export async function getAuth() {
+  if (!_authPromise) {
+    _authPromise = (async () => {
+      const config = getEnv();
+      const isSA = config.AUTH_MODE === "service_account";
+      const scopes = isSA ? [] : await resolveAdminScopes(config.MCP_SERVER_URL);
+      return createAuth(scopes);
+    })();
   }
-  return _auth;
+  return _authPromise;
 }

--- a/mcp-examples/pocket-cep/src/lib/auth.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth.ts
@@ -31,6 +31,7 @@ const FALLBACK_ADMIN_SCOPES = [
   "https://www.googleapis.com/auth/chrome.management.reports.readonly",
   "https://www.googleapis.com/auth/chrome.management.profiles.readonly",
   "https://www.googleapis.com/auth/admin.reports.audit.readonly",
+  "https://www.googleapis.com/auth/admin.directory.user.readonly",
   "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
   "https://www.googleapis.com/auth/admin.directory.customer.readonly",
   "https://www.googleapis.com/auth/apps.licensing",
@@ -53,7 +54,15 @@ async function resolveAdminScopes(mcpUrl: string): Promise<string[]> {
       if (scopeParam) {
         const dynamicScopes = decodeURIComponent(scopeParam).split(/[\s+]/).filter(Boolean);
         if (dynamicScopes.length > 0) {
-          return Array.from(new Set(["openid", "email", "profile", ...dynamicScopes]));
+          return Array.from(
+            new Set([
+              "openid",
+              "https://www.googleapis.com/auth/userinfo.email",
+              "profile",
+              "https://www.googleapis.com/auth/admin.directory.user.readonly",
+              ...dynamicScopes,
+            ]),
+          );
         }
       }
     }

--- a/mcp-examples/pocket-cep/src/lib/env.ts
+++ b/mcp-examples/pocket-cep/src/lib/env.ts
@@ -124,12 +124,34 @@ function inferLlmProvider(raw: Record<string, unknown>): "claude" | "gemini" {
   return "gemini";
 }
 
+function resolveAuthMode(
+  raw: Record<string, unknown>,
+  isBuildTime: boolean,
+): "service_account" | "user_oauth" {
+  if (isBuildTime) return "user_oauth";
+  const explicit = typeof raw.AUTH_MODE === "string" ? raw.AUTH_MODE : "";
+  const clientId = typeof raw.GOOGLE_CLIENT_ID === "string" ? raw.GOOGLE_CLIENT_ID.trim() : "";
+  const clientSecret =
+    typeof raw.GOOGLE_CLIENT_SECRET === "string" ? raw.GOOGLE_CLIENT_SECRET.trim() : "";
+
+  const hasValidOauth =
+    clientId !== "" &&
+    !clientId.includes("your_client_id_here") &&
+    clientSecret !== "" &&
+    !clientSecret.includes("your_client_secret_here");
+
+  if (explicit === "service_account") return "service_account";
+  if (hasValidOauth) return "user_oauth";
+  return "service_account";
+}
+
 export const serverSchema = z.preprocess((raw) => {
   if (!isRecord(raw)) return raw;
   const isBuildTime = process.env.NEXT_PHASE === "phase-production-build";
+  const authMode = resolveAuthMode(raw, isBuildTime);
   return {
     ...raw,
-    AUTH_MODE: raw.AUTH_MODE || "service_account",
+    AUTH_MODE: authMode,
     LLM_PROVIDER: inferLlmProvider(raw),
     BETTER_AUTH_SECRET:
       raw.BETTER_AUTH_SECRET || (isBuildTime ? "build-time-placeholder-secret-32ch" : undefined),

--- a/mcp-examples/pocket-cep/src/lib/env.ts
+++ b/mcp-examples/pocket-cep/src/lib/env.ts
@@ -126,10 +126,18 @@ function inferLlmProvider(raw: Record<string, unknown>): "claude" | "gemini" {
 
 export const serverSchema = z.preprocess((raw) => {
   if (!isRecord(raw)) return raw;
+  const isBuildTime = process.env.NEXT_PHASE === "phase-production-build";
   return {
     ...raw,
     AUTH_MODE: raw.AUTH_MODE || "service_account",
     LLM_PROVIDER: inferLlmProvider(raw),
+    BETTER_AUTH_SECRET:
+      raw.BETTER_AUTH_SECRET || (isBuildTime ? "build-time-placeholder-secret-32ch" : undefined),
+    GOOGLE_CLIENT_ID:
+      raw.GOOGLE_CLIENT_ID ||
+      (isBuildTime ? "123456789-placeholder.apps.googleusercontent.com" : undefined),
+    GOOGLE_CLIENT_SECRET:
+      raw.GOOGLE_CLIENT_SECRET || (isBuildTime ? "build-time-placeholder-secret" : undefined),
   };
 }, authSchema.and(llmSchema));
 

--- a/mcp-examples/pocket-cep/src/lib/mcp-client.ts
+++ b/mcp-examples/pocket-cep/src/lib/mcp-client.ts
@@ -66,6 +66,7 @@ export type McpToolDefinition = {
 async function connect(
   serverUrl: string,
   accessToken?: string,
+  signal?: AbortSignal,
 ): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
   const headers: Record<string, string> = {};
 
@@ -74,7 +75,7 @@ async function connect(
   }
 
   const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
-    requestInit: { headers },
+    requestInit: { headers, signal },
   });
 
   const client = new Client({ name: "pocket-cep", version: "1.0.0" });
@@ -116,6 +117,7 @@ export async function callMcpTool(
   toolName: string,
   args: Record<string, unknown>,
   accessToken?: string,
+  signal?: AbortSignal,
 ): Promise<McpToolResult> {
   const callArgs: Record<string, unknown> = { ...args };
   if (
@@ -138,7 +140,7 @@ export async function callMcpTool(
 
   console.log(LOG_TAGS.MCP, `Calling tool: ${toolName}`, JSON.stringify(callArgs));
 
-  const { client } = await connect(serverUrl, accessToken);
+  const { client } = await connect(serverUrl, accessToken, signal);
 
   try {
     const result = await client.callTool({ name: toolName, arguments: callArgs });

--- a/mcp-examples/pocket-cep/src/lib/session.ts
+++ b/mcp-examples/pocket-cep/src/lib/session.ts
@@ -20,6 +20,6 @@ import { getAuth } from "./auth";
  * inside a request context (route handler or server action).
  */
 export async function requireSession() {
-  const auth = getAuth();
+  const auth = await getAuth();
   return auth.api.getSession({ headers: await headers() });
 }


### PR DESCRIPTION
## Overview

This PR refactors Pocket CEP's authentication architecture to default to Google OAuth (`user_oauth`) and dynamically resolve requested API scopes from the upstream Chrome Enterprise Premium MCP server.

## Summary of Changes

1. **Default Authentication Mode**:
   - Switched default configuration in `.env` to `AUTH_MODE=user_oauth`.
   - Updated `scripts/setup.ts` and `README.md` to guide users through Google OAuth client configuration first, retaining `gcloud` ADC as an optional local demo fallback.

2. **Dynamic MCP Scope Discovery**:
   - Added `resolveAdminScopes()` in `src/lib/auth.ts` to dynamically query requested OAuth scopes by invoking the MCP server's `cep_auth` tool in `manual` mode.
   - Updated fallback scopes in `src/lib/auth.ts` to accurately match `OAUTH_SCOPES` from `chrome-enterprise-premium-mcp`.
   - Included `https://www.googleapis.com/auth/admin.directory.user.readonly` to ensure Directory API user searches (`GET /api/users`) succeed.

3. **Seamless Re-Authentication UI**:
   - Updated `AuthBanner` (`src/components/auth-banner.tsx`) to render an interactive **Sign in with Google** button when running in `user_oauth` mode.
   - Prevented unexpected fallbacks to local machine ADC in `admin-sdk.ts`, `activity-data.ts`, and `auth-errors.ts`.

4. **Welcome Card Visual Formatting**:
   - Refactored the landing page sign-in card (`src/app/page.tsx`) with structured spacing, crisp typography, and scannable bullet points highlighting core capabilities.