### PR TITLE
fix(test): hotfix auth-errors unit test mock for ServerEnv compatibility

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/unit/auth-errors.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/auth-errors.test.ts
@@ -142,6 +142,8 @@ describe("toAuthError", () => {
         BETTER_AUTH_URL: "http://localhost:3000",
         MCP_SERVER_URL: "http://localhost:4000/mcp",
         LLM_MODEL: "",
+        GOOGLE_CLIENT_ID: "",
+        GOOGLE_CLIENT_SECRET: "",
         LLM_PROVIDER: "gemini",
         ANTHROPIC_API_KEY: "",
         GOOGLE_AI_API_KEY: "",


### PR DESCRIPTION
#### Motivation
A type compilation error was introduced on `main` in `src/__tests__/unit/auth-errors.test.ts` where the mocked `getEnv` was missing `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` properties required by the `ServerEnv` type under `service_account` mode.

#### Main Changes
* Add missing `GOOGLE_CLIENT_ID: ""` and `GOOGLE_CLIENT_SECRET: ""` to the mocked `getEnv` return value in `auth-errors.test.ts`.

TAG=agy
CONV=ff58ca61-3763-4cf3-aef4-4a279152b67a
