### PR TITLE
Fix model selector fallback and default to Gemini

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/unit/auth-errors.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/auth-errors.test.ts
@@ -142,6 +142,8 @@ describe("toAuthError", () => {
         BETTER_AUTH_URL: "http://localhost:3000",
         MCP_SERVER_URL: "http://localhost:4000/mcp",
         LLM_MODEL: "",
+        GOOGLE_CLIENT_ID: "",
+        GOOGLE_CLIENT_SECRET: "",
         LLM_PROVIDER: "gemini",
         ANTHROPIC_API_KEY: "",
         GOOGLE_AI_API_KEY: "",

--- a/mcp-examples/pocket-cep/src/__tests__/unit/env.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/env.test.ts
@@ -36,33 +36,32 @@ describe("serverSchema", () => {
     expect(serverSchema.safeParse(VALID_GEMINI_OAUTH).success).toBe(true);
   });
 
-  it("applies defaults when optional fields are omitted (only Claude key)", () => {
+  it("applies defaults when optional fields are omitted", () => {
     const result = serverSchema.safeParse({
       BETTER_AUTH_SECRET: "my-secret",
-      ANTHROPIC_API_KEY: "sk-ant-key",
     });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.AUTH_MODE).toBe("service_account");
-      expect(result.data.LLM_PROVIDER).toBe("claude");
+      expect(result.data.LLM_PROVIDER).toBe("gemini");
       expect(result.data.MCP_SERVER_URL).toBe("http://localhost:4000/mcp");
     }
   });
 
-  it("defaults to gemini when both keys are omitted", () => {
-    const result = serverSchema.safeParse({
-      BETTER_AUTH_SECRET: "my-secret",
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.LLM_PROVIDER).toBe("gemini");
-    }
-  });
-
-  it("defaults to gemini when both keys are present", () => {
+  it("infers provider from present key when provider is unset (only Claude key)", () => {
     const result = serverSchema.safeParse({
       BETTER_AUTH_SECRET: "my-secret",
       ANTHROPIC_API_KEY: "sk-ant-key",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.LLM_PROVIDER).toBe("claude");
+    }
+  });
+
+  it("infers provider from present key when provider is unset (only Gemini key)", () => {
+    const result = serverSchema.safeParse({
+      BETTER_AUTH_SECRET: "my-secret",
       GOOGLE_AI_API_KEY: "ai-gemini-key",
     });
     expect(result.success).toBe(true);
@@ -71,9 +70,10 @@ describe("serverSchema", () => {
     }
   });
 
-  it("defaults to gemini when only Gemini key is present", () => {
+  it("defaults to gemini when provider is unset and both keys are present", () => {
     const result = serverSchema.safeParse({
       BETTER_AUTH_SECRET: "my-secret",
+      ANTHROPIC_API_KEY: "sk-ant-key",
       GOOGLE_AI_API_KEY: "ai-gemini-key",
     });
     expect(result.success).toBe(true);

--- a/mcp-examples/pocket-cep/src/__tests__/unit/env.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/env.test.ts
@@ -36,7 +36,7 @@ describe("serverSchema", () => {
     expect(serverSchema.safeParse(VALID_GEMINI_OAUTH).success).toBe(true);
   });
 
-  it("applies defaults when optional fields are omitted", () => {
+  it("applies defaults when optional fields are omitted (only Claude key)", () => {
     const result = serverSchema.safeParse({
       BETTER_AUTH_SECRET: "my-secret",
       ANTHROPIC_API_KEY: "sk-ant-key",
@@ -46,6 +46,39 @@ describe("serverSchema", () => {
       expect(result.data.AUTH_MODE).toBe("service_account");
       expect(result.data.LLM_PROVIDER).toBe("claude");
       expect(result.data.MCP_SERVER_URL).toBe("http://localhost:4000/mcp");
+    }
+  });
+
+  it("defaults to gemini when both keys are omitted", () => {
+    const result = serverSchema.safeParse({
+      BETTER_AUTH_SECRET: "my-secret",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.LLM_PROVIDER).toBe("gemini");
+    }
+  });
+
+  it("defaults to gemini when both keys are present", () => {
+    const result = serverSchema.safeParse({
+      BETTER_AUTH_SECRET: "my-secret",
+      ANTHROPIC_API_KEY: "sk-ant-key",
+      GOOGLE_AI_API_KEY: "ai-gemini-key",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.LLM_PROVIDER).toBe("gemini");
+    }
+  });
+
+  it("defaults to gemini when only Gemini key is present", () => {
+    const result = serverSchema.safeParse({
+      BETTER_AUTH_SECRET: "my-secret",
+      GOOGLE_AI_API_KEY: "ai-gemini-key",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.LLM_PROVIDER).toBe("gemini");
     }
   });
 

--- a/mcp-examples/pocket-cep/src/components/model-selector.tsx
+++ b/mcp-examples/pocket-cep/src/components/model-selector.tsx
@@ -99,6 +99,24 @@ export function ModelSelector() {
   const readyModels = MODEL_OPTIONS.filter((m) => isReady(m));
   const needsKeyModels = MODEL_OPTIONS.filter((m) => !isReady(m));
 
+  // Auto-default to a ready model if the currently selected one is not ready
+  useEffect(() => {
+    const currentOpt = getModelById(selected);
+    if (!currentOpt || !isReady(currentOpt)) {
+      // Fallback 1: Server default
+      const serverDefaultOpt = getModelById(mode.llmModel);
+      if (serverDefaultOpt && isReady(serverDefaultOpt)) {
+        setSelected(mode.llmModel);
+        return;
+      }
+      // Fallback 2: First ready model
+      const firstReady = MODEL_OPTIONS.find((m) => isReady(m));
+      if (firstReady) {
+        setSelected(firstReady.id);
+      }
+    }
+  }, [selected, mode.llmModel, byokKeys, setSelected]);
+
   function selectModel(opt: ModelOption) {
     if (!isReady(opt)) {
       setKeyEditorFor(opt.id);

--- a/mcp-examples/pocket-cep/src/lib/env.ts
+++ b/mcp-examples/pocket-cep/src/lib/env.ts
@@ -120,8 +120,8 @@ function inferLlmProvider(raw: Record<string, unknown>): "claude" | "gemini" {
     typeof raw.GOOGLE_AI_API_KEY === "string" && raw.GOOGLE_AI_API_KEY.trim() !== "";
   const hasClaude =
     typeof raw.ANTHROPIC_API_KEY === "string" && raw.ANTHROPIC_API_KEY.trim() !== "";
-  if (hasGemini && !hasClaude) return "gemini";
-  return "claude";
+  if (hasClaude && !hasGemini) return "claude";
+  return "gemini";
 }
 
 export const serverSchema = z.preprocess((raw) => {


### PR DESCRIPTION
#### Motivation
1. The model selector UI defaulted to Claude Sonnet even when the user configured `LLM_PROVIDER=gemini` (if they had a stale preference in `localStorage`), leading to immediate chat failures if they lacked an Anthropic API key.
2. When `LLM_PROVIDER` was unset, the app defaulted to Claude, which was less ideal than defaulting to Gemini as the baseline Google model for this Google-adjacent tool.

Stacked on top of #48.

#### Main Changes
* **Model Selector Fallback**: Added auto-fallback in `ModelSelector` to redirect the selection to a ready model (like the server default) if the client's stored selection is not ready (missing keys).
* **Gemini as Default**: Updated `inferLlmProvider` to default to `gemini` instead of `claude` when `LLM_PROVIDER` is unset (unless only the Claude key is present). Added corresponding tests.

#### Design Decisions
* Handled the stale `localStorage` issue client-side by validating readiness before applying the stored selection, ensuring a smooth default experience without clearing user storage.

TAG=agy
CONV=ff58ca61-3763-4cf3-aef4-4a279152b67a
