### PR TITLE
docs: clarify service_account mode behavior in .env

### DIFF
--- a/mcp-examples/pocket-cep/.env
+++ b/mcp-examples/pocket-cep/.env
@@ -16,8 +16,8 @@
 # server. Two modes are available:
 #
 #   "service_account" — The MCP server uses Application Default Credentials
-#     (ADC) from the machine it runs on. The user signs into Pocket CEP with
-#     basic Google OAuth (openid, email, profile) just to access the UI.
+#     (ADC) from the machine it runs on. Pocket CEP automatically creates an
+#     anonymous session for UI access (no Google Sign-In is required to use the web app).
 #     Simpler to set up; good for demos where the server already has ADC.
 #
 #   "user_oauth" — The user signs in with the full set of Google Admin scopes.


### PR DESCRIPTION
Updates the default `.env` file comments to match the actual implementation (anonymous session, no Google Sign-In required in `service_account` mode).

TAG=agy
CONV=ff58ca61-3763-4cf3-aef4-4a279152b67a
