### PR TITLE
docs: clarify custom Web OAuth client requirements

### DIFF
--- a/mcp-examples/pocket-cep/.env.local.example
+++ b/mcp-examples/pocket-cep/.env.local.example
@@ -38,8 +38,9 @@ GOOGLE_AI_API_KEY=
 # -----------------------------------------------------------------------------
 # Google OAuth (only needed when AUTH_MODE=user_oauth)
 # -----------------------------------------------------------------------------
-# console.cloud.google.com → APIs & Services → Credentials → OAuth client ID
-# Add this redirect URI to the client:
+# console.cloud.google.com → APIs & Services → Credentials → Create Credentials → OAuth client ID
+# Select application type: "Web application" (Desktop apps will not work).
+# Add this Authorized redirect URI:
 #   http://localhost:3000/api/auth/callback/google
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/mcp-examples/pocket-cep/.env.local.example
+++ b/mcp-examples/pocket-cep/.env.local.example
@@ -39,7 +39,7 @@ GOOGLE_AI_API_KEY=
 # Google OAuth (only needed when AUTH_MODE=user_oauth)
 # -----------------------------------------------------------------------------
 # console.cloud.google.com → APIs & Services → Credentials → Create Credentials → OAuth client ID
-# Select application type: "Web application" (Desktop apps will not work).
+# Select application type: "Web application" ("Desktop app" will not work).
 # Add this Authorized redirect URI:
 #   http://localhost:3000/api/auth/callback/google
 GOOGLE_CLIENT_ID=

--- a/mcp-examples/pocket-cep/README.md
+++ b/mcp-examples/pocket-cep/README.md
@@ -164,6 +164,7 @@ Pocket CEP supports two authentication modes that control how it communicates wi
 - When you need per-user audit trails in Google Admin logs
 
 **Requirements:**
+- **Custom OAuth Client**: A custom Google Cloud **OAuth client ID (Web Application type)**. Unlike the MCP CLI, Pocket CEP does not ship with a bundled Google-managed OAuth client. You must create your own and configure the redirect URI `http://localhost:3000/api/auth/callback/google` (see [Configuration](#configuration)).
 - The signed-in user must be a Google Workspace administrator
 - The MCP server should be started with `OAUTH_ENABLED=true`
 

--- a/mcp-examples/pocket-cep/README.md
+++ b/mcp-examples/pocket-cep/README.md
@@ -45,7 +45,7 @@ The app is deliberately educational. An **MCP Inspector** panel shows every JSON
 ## Prerequisites
 
 - **Node.js** 18 or later
-- **Google Cloud project** with OAuth 2.0 credentials or a Service Account configured
+- **Google Cloud project** with the [required Workspace and Chrome APIs enabled](https://github.com/google/chrome-enterprise-premium-mcp/blob/main/docs/auth-bring-your-own-oauth-client.md#enable-required-apis) and OAuth 2.0 credentials or a Service Account configured
 - **LLM API key** for either Anthropic (Claude) or Google AI (Gemini)
 - **Google Cloud CLI** (`gcloud`) for `service_account` mode ADC setup
 
@@ -164,9 +164,8 @@ Pocket CEP supports two authentication modes that control how it communicates wi
 - When you need per-user audit trails in Google Admin logs
 
 **Requirements:**
-- **Custom OAuth Client**: A custom Google Cloud **OAuth client ID (Web Application type)**. Unlike the MCP CLI, Pocket CEP does not ship with a bundled Google-managed OAuth client. You must create your own and configure the redirect URI `http://localhost:3000/api/auth/callback/google` (see [Configuration](#configuration)).
+- **Custom OAuth Client**: A custom Google Cloud **OAuth client ID ("Web application" type)**. Unlike the MCP CLI, Pocket CEP does not ship with a bundled Google-managed OAuth client. You must create your own and configure the redirect URI `http://localhost:3000/api/auth/callback/google` (see [Configuration](#configuration)).
 - The signed-in user must be a Google Workspace administrator
-- The MCP server should be started with `OAUTH_ENABLED=true`
 
 ---
 


### PR DESCRIPTION
Clarifies that `user_oauth` mode in Pocket CEP requires a custom Web Application OAuth client ID (not desktop) and that there is no bundled Google-managed 1p client available, aligning with the actual configuration requirements.