### PR TITLE
fix: improve auth error mapping in Service Account Direct Mode

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/unit/auth-errors.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/auth-errors.test.ts
@@ -75,6 +75,36 @@ describe("toAuthError", () => {
       expect(result?.command).toBeUndefined();
       expect(result?.remedy).toContain("/sa-setup");
     });
+
+    it("maps 'Invalid Customer Id' to unauthenticated when impersonatedUser is missing", () => {
+      vi.mocked(getEnv).mockReturnValue({
+        AUTH_MODE: "service_account",
+        BETTER_AUTH_SECRET: "secret",
+        BETTER_AUTH_URL: "http://localhost:3000",
+        MCP_SERVER_URL: "http://localhost:4000/mcp",
+        LLM_MODEL: "",
+        CEP_IMPERSONATE_SUBJECT: "", // Empty to simulate missing impersonated user
+        CEP_CUSTOMER_ID: "C012345",
+        GOOGLE_CLIENT_ID: "",
+        GOOGLE_CLIENT_SECRET: "",
+        LLM_PROVIDER: "gemini",
+        ANTHROPIC_API_KEY: "",
+        GOOGLE_AI_API_KEY: "",
+        OPENAI_API_KEY: "",
+      });
+
+      const err = new Error("Invalid Customer Id");
+      const result = toAuthError(err, "admin-sdk"); // context has no impersonatedUser
+      expect(result?.code).toBe("unauthenticated");
+      expect(result?.remedy).toContain("require an admin user to impersonate");
+    });
+
+    it("maps 'Invalid Customer Id' to invalid_customer_id when impersonatedUser is present", () => {
+      const err = new Error("Invalid Customer Id");
+      const result = toAuthError(err, "admin-sdk", { impersonatedUser: "admin@example.com" });
+      expect(result?.code).toBe("invalid_customer_id");
+      expect(result?.remedy).toContain("Verify or set your active Workspace Customer ID");
+    });
   });
 
   describe("in user_oauth mode", () => {
@@ -130,6 +160,14 @@ describe("toAuthError", () => {
       expect(result?.code).toBe("no_credentials");
       expect(result?.command).toBeUndefined();
       expect(result?.remedy).toContain("Please sign in with your Google account");
+    });
+
+    it("maps 'Invalid Customer Id' to invalid_customer_id in user_oauth mode with user remedy", () => {
+      const err = new Error("Invalid Customer Id");
+      const result = toAuthError(err, "admin-sdk");
+      expect(result?.code).toBe("invalid_customer_id");
+      expect(result?.remedy).toContain("Ensure the Customer ID parameter passed to the tool is correct");
+      expect(result?.remedy).not.toContain("/sa-setup");
     });
   });
 

--- a/mcp-examples/pocket-cep/src/lib/activity-data.ts
+++ b/mcp-examples/pocket-cep/src/lib/activity-data.ts
@@ -15,6 +15,7 @@ import { buildCallerCacheKey } from "./cache-key";
 import { LOG_TAGS } from "./constants";
 import { getErrorMessage } from "./errors";
 import { getOrFetch, CACHE_TAGS } from "./server-cache";
+import { getServiceAccountConfig } from "./sa-session";
 
 /**
  * Per-user activity summary: event count and most recent event timestamp.
@@ -64,13 +65,15 @@ export async function getCachedActivity(
       remedy: "Configure your credentials or sign in.",
     });
   }
+  const saConfig = config.AUTH_MODE === "service_account" ? await getServiceAccountConfig() : null;
+  const impersonatedUser = saConfig?.impersonatedUser;
   const callerKey = buildCallerCacheKey(config.MCP_SERVER_URL, accessToken);
 
   return getOrFetch({
     key: `activity:${callerKey}:${days}`,
     ttlMs: ACTIVITY_TTL_MS,
     tags: [CACHE_TAGS.ACTIVITY],
-    fetcher: () => fetchActivity(accessToken, days),
+    fetcher: () => fetchActivity(accessToken, days, impersonatedUser),
   });
 }
 
@@ -97,7 +100,7 @@ export async function getActivitySafe(days: number = DEFAULT_ACTIVITY_DAYS): Pro
  * Pulls and groups Chrome audit events for the given caller, scoped to
  * `days` of history. Pagination stops at {@link ACTIVITY_MAX_EVENTS}.
  */
-async function fetchActivity(tokenToUse: string, days: number): Promise<ActivityMap> {
+async function fetchActivity(tokenToUse: string, days: number, impersonatedUser?: string): Promise<ActivityMap> {
   const requestHeaders = await buildGoogleApiHeaders(tokenToUse);
 
   const baseUrl = new URL(
@@ -126,7 +129,7 @@ async function fetchActivity(tokenToUse: string, days: number): Promise<Activity
 
     if (!response.ok) {
       const body = await response.text().catch(() => "");
-      const authErr = toAuthError(body, "admin-sdk");
+      const authErr = toAuthError(body, "admin-sdk", { impersonatedUser });
       if (authErr) throw authErr;
       console.log(LOG_TAGS.USERS, "Activity fetch failed with status:", response.status, body);
       break;

--- a/mcp-examples/pocket-cep/src/lib/admin-sdk.ts
+++ b/mcp-examples/pocket-cep/src/lib/admin-sdk.ts
@@ -6,7 +6,7 @@ import { getErrorMessage } from "./errors";
 import { LOG_TAGS } from "./constants";
 import { buildGoogleApiHeaders } from "./access-token";
 import { AuthError, isAuthError, toAuthError } from "./auth-errors";
-import { getActiveCustomerId } from "./sa-session";
+import { getActiveCustomerId, getServiceAccountConfig } from "./sa-session";
 
 /**
  * Converts a user-typed search string into Admin SDK query syntax.
@@ -45,6 +45,8 @@ export async function searchUsers(
   maxResults = 20,
 ): Promise<DirectoryUser[]> {
   const customerId = await getActiveCustomerId();
+  const saConfig = await getServiceAccountConfig();
+  const impersonatedUser = saConfig?.impersonatedUser;
   const params = new URLSearchParams({
     customer: customerId || "my_customer",
     maxResults: String(maxResults),
@@ -84,7 +86,7 @@ export async function searchUsers(
        * classify — route it through the same AuthError contract so the
        * banner still lights up.
        */
-      const authErr = toAuthError(body, "admin-sdk");
+      const authErr = toAuthError(body, "admin-sdk", { impersonatedUser });
       if (authErr) throw authErr;
       console.error(LOG_TAGS.USERS, `Admin SDK users.list failed (${response.status}):`, body);
       return [];

--- a/mcp-examples/pocket-cep/src/lib/auth-errors.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth-errors.ts
@@ -269,8 +269,9 @@ function buildPayload(
         code,
         source,
         message: "Google Workspace Customer ID is invalid, missing, or unauthorized.",
-        remedy:
-          "Verify or set your active Workspace Customer ID (e.g. `C0...`) on the [Service Account Setup](/sa-setup) page. Note that using 'my_customer' is only supported when Domain-Wide Delegation (impersonation) is enabled. If your Customer ID is already set, ensure it is correct and that your Service Account has been assigned the required admin roles in Google Workspace Admin Console.",
+        remedy: isSaMode
+          ? "Verify or set your active Workspace Customer ID (e.g. `C0...`) on the [Service Account Setup](/sa-setup) page. Note that using 'my_customer' is only supported when Domain-Wide Delegation (impersonation) is enabled. If your Customer ID is already set, ensure it is correct and that your Service Account has been assigned the required admin roles in Google Workspace Admin Console."
+          : "Ensure the Customer ID parameter passed to the tool is correct, and that your Google account has permission to access this customer (by default, 'my_customer' resolves to your own organization).",
         docsUrl,
       };
     case "unknown_auth":

--- a/mcp-examples/pocket-cep/src/lib/auth-errors.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth-errors.ts
@@ -268,9 +268,9 @@ function buildPayload(
       return {
         code,
         source,
-        message: "Google Workspace Customer ID is invalid or not found.",
+        message: "Google Workspace Customer ID is invalid, missing, or unauthorized.",
         remedy:
-          "Set your active Workspace Customer ID (e.g. `my_customer` or `C0...`) on the [Service Account Setup](/sa-setup) page.",
+          "Verify or set your active Workspace Customer ID (e.g. `C0...`) on the [Service Account Setup](/sa-setup) page. Note that using 'my_customer' is only supported when Domain-Wide Delegation (impersonation) is enabled. If your Customer ID is already set, ensure it is correct and that your Service Account has been assigned the required admin roles in Google Workspace Admin Console.",
         docsUrl,
       };
     case "unknown_auth":
@@ -298,7 +298,11 @@ function buildPayload(
  *     `UNAUTHENTICATED`, or the "Could not load the default credentials" phrase
  *   - MCP tool-error strings like "API Error: invalid_grant - ..."
  */
-export function toAuthError(err: unknown, source: AuthErrorPayload["source"]): AuthError | null {
+export function toAuthError(
+  err: unknown,
+  source: AuthErrorPayload["source"],
+  context?: { impersonatedUser?: string },
+): AuthError | null {
   if (err instanceof AuthError) return err;
   if (
     typeof err === "object" &&
@@ -365,6 +369,9 @@ export function toAuthError(err: unknown, source: AuthErrorPayload["source"]): A
     return new AuthError(buildPayload("invalid_grant", source));
   }
   if (/Invalid Customer Id|Invalid value for customer id/i.test(message)) {
+    if (isSaMode && !context?.impersonatedUser) {
+      return new AuthError(buildPayload("unauthenticated", source));
+    }
     return new AuthError(buildPayload("invalid_customer_id", source));
   }
   if (

--- a/mcp-examples/pocket-cep/src/lib/mcp-tools.ts
+++ b/mcp-examples/pocket-cep/src/lib/mcp-tools.ts
@@ -17,6 +17,7 @@ import { callMcpTool, listMcpTools, type McpToolDefinition } from "./mcp-client"
 import { toAuthError } from "./auth-errors";
 import { buildCallerCacheKey } from "./cache-key";
 import { LOG_TAGS } from "./constants";
+import { getServiceAccountConfig } from "./sa-session";
 
 const TOOL_CATALOG_TTL_MS = 5 * 60 * 1000;
 
@@ -89,7 +90,10 @@ export async function getMcpToolsForAiSdk(
          */
         if (result.isError) {
           const text = extractErrorText(result.content);
-          const authErr = toAuthError(text, "mcp-tool");
+          const saConfig = await getServiceAccountConfig();
+          const authErr = toAuthError(text, "mcp-tool", {
+            impersonatedUser: saConfig?.impersonatedUser,
+          });
           if (authErr) throw authErr;
         }
 


### PR DESCRIPTION
When running in Service Account mode without Domain-Wide Delegation, API calls that try to resolve `my_customer` will fail with an "Invalid Customer Id" error from Gaia. Previously, this was mapped to an `invalid_customer_id` error, which incorrectly told the user to configure their Customer ID, even if they had already set it.

This change passes the `impersonatedUser` context to `toAuthError`. If an "Invalid Customer Id" error is encountered while running in SA mode without an impersonated user, it is now correctly mapped to `unauthenticated` (missing impersonation), pointing the user to set up DWD instead.

TAG=agy
CONV=229f3193-9b20-4bd1-96b1-e96f2ccbe456
