### PR TITLE
fix(setup): prioritize User OAuth in chooseAuthMode

### DIFF
--- a/mcp-examples/pocket-cep/scripts/setup.ts
+++ b/mcp-examples/pocket-cep/scripts/setup.ts
@@ -132,17 +132,17 @@ async function chooseAuthMode(current: string | undefined) {
   return ask<"service_account" | "user_oauth">(
     p.select({
       message: "How does Pocket CEP talk to Google APIs?",
-      initialValue: current === "user_oauth" ? "user_oauth" : "service_account",
+      initialValue: current === "service_account" ? "service_account" : "user_oauth",
       options: [
         {
-          label: "Service account (recommended for local demos)",
-          value: "service_account",
-          hint: "Uses `gcloud auth application-default login`. No user sign-in; shared identity.",
-        },
-        {
-          label: "User OAuth (per-user attribution)",
+          label: "User OAuth (recommended — per-user attribution)",
           value: "user_oauth",
           hint: "Users sign in with Google. Their token is forwarded to the MCP server.",
+        },
+        {
+          label: "Service account (local demo fallback)",
+          value: "service_account",
+          hint: "Uses `gcloud auth application-default login`. No user sign-in; shared identity.",
         },
       ],
     }),


### PR DESCRIPTION
Fixes setup script prioritization omission from PR #59.

### What
- Reordered options in `chooseAuthMode` (Step 1) in `scripts/setup.ts` to present "User OAuth" first.
- Defaulted `initialValue` to `"user_oauth"` when running setup with no existing configuration.
- Updated the "Service Account" option's label to "local demo fallback" to de-prioritize it.

### Why
- PR #59 was intended to prioritize User OAuth but missed modifying `chooseAuthMode`.