### PR TITLE
chore(cleanup): remove obsolete gcloud and ADC references

### DIFF
--- a/mcp-examples/pocket-cep/scripts/setup.ts
+++ b/mcp-examples/pocket-cep/scripts/setup.ts
@@ -142,7 +142,7 @@ async function chooseAuthMode(current: string | undefined) {
         {
           label: "Service account (local demo fallback)",
           value: "service_account",
-          hint: "Uses `gcloud auth application-default login`. No user sign-in; shared identity.",
+          hint: "Uses machine credentials (JSON key). No user sign-in; shared identity.",
         },
       ],
     }),

--- a/mcp-examples/pocket-cep/src/__tests__/integration/api/auth-health-route.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/integration/api/auth-health-route.test.ts
@@ -1,8 +1,8 @@
 /**
  * @file Integration test for GET /api/auth/health.
  *
- * Probes ADC credentials on demand. Used by the auth-banner "Check
- * again" button to clear the banner after the user runs gcloud auth login.
+ * Probes Google credentials on demand. Used by the auth-banner "Check
+ * again" button to clear the banner after the user signs in again.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/mcp-examples/pocket-cep/src/__tests__/integration/api/users-route.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/integration/api/users-route.test.ts
@@ -80,9 +80,8 @@ describe("GET /api/users", () => {
       new AuthError({
         code: "invalid_rapt",
         source: "admin-sdk",
-        message: "Google requires you to re-authenticate.",
-        remedy: "Run `gcloud auth login` and retry.",
-        command: "gcloud auth login",
+        message: "Your session has expired. Please sign in again.",
+        remedy: "Click the Sign In button to log back into your Google account.",
       }),
     );
 
@@ -92,9 +91,8 @@ describe("GET /api/users", () => {
     expect(body.error).toEqual({
       code: "invalid_rapt",
       source: "admin-sdk",
-      message: "Google requires you to re-authenticate.",
-      remedy: "Run `gcloud auth login` and retry.",
-      command: "gcloud auth login",
+      message: "Your session has expired. Please sign in again.",
+      remedy: "Click the Sign In button to log back into your Google account.",
       docsUrl: undefined,
     });
   });

--- a/mcp-examples/pocket-cep/src/__tests__/unit/google-scopes.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/google-scopes.test.ts
@@ -1,6 +1,5 @@
 /**
- * @file Tests for the canonical Google API scope list and the
- * `gcloud auth application-default login` formatter that consumes it.
+ * @file Tests for the canonical Google API scope list.
  */
 
 import { describe, it, expect } from "vitest";

--- a/mcp-examples/pocket-cep/src/app/api/auth/health/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/auth/health/route.ts
@@ -1,12 +1,12 @@
 /**
- * @file Health probe for Google ADC credentials.
+ * @file Health probe for Google credentials.
  *
  * GET /api/auth/health
- *   200 { ok: true }                — ADC is valid
+ *   200 { ok: true }                — Credentials are valid
  *   401 { ok: false, error: AuthErrorPayload } — re-auth required
  *
  * Used by the auth-banner "Check again" button to verify the user has
- * re-run `gcloud auth login`. No side effects, no cache — each call
+ * signed in again. No side effects, no cache — each call
  * exchanges the refresh token fresh.
  */
 
@@ -17,8 +17,8 @@ import { requireSession } from "@/lib/session";
 import { getErrorMessage } from "@/lib/errors";
 
 /**
- * Probes ADC by requesting a fresh access token. Returns 200 if Google
- * issues one and 401 with the structured payload if it refuses.
+ * Probes Google credentials by requesting a fresh access token. Returns 200
+ * if Google issues one and 401 with the structured payload if it refuses.
  */
 export async function GET() {
   if (!(await requireSession())) {


### PR DESCRIPTION
Cleans up remaining obsolete `gcloud` and ADC references after the removal of ADC support in PR #53.

### What
- **Setup Script**: Updated the "Service Account" option's hint in `scripts/setup.ts` to remove the obsolete `gcloud auth application-default login` reference and instead describe machine credentials/JSON key.
- **Comments**: Removed outdated comments referring to `gcloud auth login` and `ADC` in `health/route.ts`, `google-scopes.test.ts`, and `auth-health-route.test.ts`.
- **Tests**: Updated the mock `AuthError` in `users-route.test.ts` to use a realistic User OAuth expired session remedy instead of referencing `gcloud auth login`.

### Why
- PR #53 removed ADC support but missed cleaning up these references, leaving misleading guidance in setup hints and outdated code comments/test mocks.