### PR TITLE
fix(auth): auto-recover from stale sessions in Service Account mode (silent JSON refresh)

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/unit/session.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/session.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetSession, mockCookies } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockCookies: {
+    getAll: vi.fn(() => [] as { name: string; value: string }[]),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+  cookies: async () => mockCookies,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuth: () => ({
+    api: {
+      getSession: mockGetSession,
+    },
+  }),
+}));
+
+vi.mock("@/lib/env", () => ({
+  getEnv: () => ({
+    AUTH_MODE: "service_account",
+    BETTER_AUTH_SECRET: "mock-secret",
+  }),
+}));
+
+import { requireSession } from "@/lib/session";
+
+describe("requireSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns session when getSession succeeds", async () => {
+    const mockSession = { user: { id: "u1" } };
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const session = await requireSession();
+    expect(session).toBe(mockSession);
+    expect(mockCookies.delete).not.toHaveBeenCalled();
+  });
+
+  it("clears stale cookies and returns null when getSession returns null", async () => {
+    mockGetSession.mockResolvedValue(null);
+    mockCookies.getAll.mockReturnValue([
+      { name: "better-auth.session_token", value: "stale-val" },
+      { name: "other-cookie", value: "val" },
+    ]);
+
+    const session = await requireSession();
+    expect(session).toBeNull();
+    expect(mockCookies.delete).toHaveBeenCalledWith("better-auth.session_token");
+    expect(mockCookies.delete).not.toHaveBeenCalledWith("other-cookie");
+  });
+
+  it("does not delete anything if no session cookies are present and getSession returns null", async () => {
+    mockGetSession.mockResolvedValue(null);
+    mockCookies.getAll.mockReturnValue([{ name: "other-cookie", value: "val" }]);
+
+    const session = await requireSession();
+    expect(session).toBeNull();
+    expect(mockCookies.delete).not.toHaveBeenCalled();
+  });
+});

--- a/mcp-examples/pocket-cep/src/app/api/auth/auto-session/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/auth/auto-session/route.ts
@@ -38,6 +38,8 @@ export async function GET(request: Request) {
   const reqUrl = new URL(request.url);
   const base = `${reqUrl.protocol}//${reqUrl.host}`;
 
+  const acceptJson = request.headers.get("accept")?.includes("application/json");
+
   let response: Response;
   try {
     response = await fetch(`${base}/api/auth/sign-in/anonymous`, {
@@ -47,14 +49,29 @@ export async function GET(request: Request) {
       signal: AbortSignal.timeout(5000),
     });
   } catch {
+    if (acceptJson) {
+      return NextResponse.json({ error: "session_unavailable" }, { status: 503 });
+    }
     return NextResponse.redirect(new URL("/?error=session_unavailable", base));
   }
 
   if (!response.ok) {
+    if (acceptJson) {
+      return NextResponse.json({ error: "session_failed" }, { status: 401 });
+    }
     return NextResponse.redirect(new URL("/?error=session_failed", base));
   }
 
   const cookies = response.headers.getSetCookie();
+
+  if (acceptJson) {
+    const headers = new Headers();
+    for (const cookie of cookies) {
+      headers.append("Set-Cookie", cookie);
+    }
+    return NextResponse.json({ success: true }, { headers });
+  }
+
   const headers = new Headers({ Location: new URL("/dashboard", base).toString() });
   for (const cookie of cookies) {
     headers.append("Set-Cookie", cookie);

--- a/mcp-examples/pocket-cep/src/components/auth-health-provider.tsx
+++ b/mcp-examples/pocket-cep/src/components/auth-health-provider.tsx
@@ -17,6 +17,7 @@ import { createContext, useCallback, useContext, useEffect, useState } from "rea
 import type { ReactNode } from "react";
 import type { AuthErrorPayload } from "@/lib/auth-errors";
 import { AUTH_ERROR_EVENT } from "@/lib/auth-aware-fetch";
+import { useMode } from "./mode-provider";
 
 /**
  * Value exposed by the AuthHealthContext. `clear()` drops the current
@@ -38,6 +39,7 @@ const AuthHealthContext = createContext<AuthHealthValue | null>(null);
  */
 export function AuthHealthProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<AuthErrorPayload | null>(null);
+  const mode = useMode();
 
   const report = useCallback((payload: AuthErrorPayload) => {
     setError(payload);
@@ -50,13 +52,37 @@ export function AuthHealthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     function handler(event: Event) {
       const detail = (event as CustomEvent<AuthErrorPayload>).detail;
-      if (detail && typeof detail.code === "string") {
+      if (detail && detail.code === "unauthenticated" && mode.authMode === "service_account") {
+        console.warn(
+          "AuthHealthProvider: Stale session detected in Service Account mode. " +
+            "Attempting background silent refresh...",
+        );
+        fetch("/api/auth/auto-session", {
+          headers: { Accept: "application/json" },
+        })
+          .then((res) => {
+            if (res.ok) {
+              console.log("AuthHealthProvider: Silent session refresh succeeded.");
+              clear();
+            } else {
+              console.error(
+                `AuthHealthProvider: Silent refresh failed with status ${res.status}. ` +
+                  "Fallback to hard redirect.",
+              );
+              window.location.href = "/api/auth/auto-session";
+            }
+          })
+          .catch((err) => {
+            console.error("AuthHealthProvider: Silent refresh network error:", err);
+            window.location.href = "/api/auth/auto-session";
+          });
+      } else if (detail && typeof detail.code === "string") {
         setError(detail);
       }
     }
     window.addEventListener(AUTH_ERROR_EVENT, handler);
     return () => window.removeEventListener(AUTH_ERROR_EVENT, handler);
-  }, []);
+  }, [clear, mode.authMode]);
 
   return (
     <AuthHealthContext.Provider value={{ error, report, clear }}>

--- a/mcp-examples/pocket-cep/src/lib/api-response.ts
+++ b/mcp-examples/pocket-cep/src/lib/api-response.ts
@@ -44,5 +44,15 @@ export function respondWithApiError(
  * protected route.
  */
 export function unauthenticatedResponse(): NextResponse {
-  return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  return NextResponse.json(
+    {
+      error: {
+        code: "unauthenticated",
+        source: "admin-sdk",
+        message: "Not authenticated",
+        remedy: "Sign in to access this resource.",
+      },
+    },
+    { status: 401 },
+  );
 }


### PR DESCRIPTION
Resolves the issue where switching auth modes (e.g. from User OAuth to Service Account) leaves invalid/stale session cookies in the browser, locking the user in a "Not Authenticated" state.

### What
- **API Response**: Updated `unauthenticatedResponse()` in `src/lib/api-response.ts` to return a structured `AuthErrorPayload` (with code `"unauthenticated"`) instead of a plain string. This enables the client-side `authAwareFetch` wrapper to catch it and dispatch the global `auth-error` event.
- **Silent Auto-Recovery**: Updated `AuthHealthProvider` in `src/components/auth-health-provider.tsx` to listen for this `"unauthenticated"` error. If in `service_account` mode, it now automatically performs a background `fetch` to `/api/auth/auto-session` requesting JSON.
- **Auto-Session JSON Support**: Updated `/api/auth/auto-session` route handler to check the `Accept` header. If it requests `application/json`, it now bypasses the 302 redirects and returns a direct JSON response (`200 { success: true }` on success, or `401`/`503` on failure) while still applying the `Set-Cookie` headers. This prevents silent redirect loops in the background if session minting fails (which would otherwise return 200 via the followed redirect to `/`).
- **Tests**: Added unit tests in `src/__tests__/unit/session.test.ts` to verify `requireSession()`'s cookie-clearing behavior when the session is invalid.

### Why
- The Next.js proxy (`src/proxy.ts`) only does a fast name-based check for the session cookie to avoid blocking requests on database lookups/decryption. 
- If a stale/invalid session cookie is present, the proxy lets the request pass to `/dashboard`.
- The subsequent API calls fail with 401. Without this fix, the UI just displays "Not Authenticated" without clearing the stale cookie or auto-recovering, requiring manual cookie deletion.
- By supporting JSON responses on `/api/auth/auto-session` and checking the `Accept` header, we prevent the browser from automatically following redirects to the home page (which returns 200 and would cause an infinite refresh loop on failure). It provides a clean, API-native way to perform silent session refresh.