### PR TITLE
fix(auth): redirect to login on stale session and ensure chat uses authAwareFetch

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/unit/session.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/session.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGetSession, mockCookies } = vi.hoisted(() => ({
+const { mockGetSession, mockCookies, mockGetEnv } = vi.hoisted(() => ({
   mockGetSession: vi.fn(),
   mockCookies: {
     getAll: vi.fn(() => [] as { name: string; value: string }[]),
     delete: vi.fn(),
   },
+  mockGetEnv: vi.fn(() => ({
+    AUTH_MODE: "service_account" as "service_account" | "user_oauth",
+    BETTER_AUTH_SECRET: "mock-secret",
+  })),
 }));
 
 vi.mock("next/headers", () => ({
@@ -22,10 +26,7 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 vi.mock("@/lib/env", () => ({
-  getEnv: () => ({
-    AUTH_MODE: "service_account",
-    BETTER_AUTH_SECRET: "mock-secret",
-  }),
+  getEnv: mockGetEnv,
 }));
 
 import { requireSession } from "@/lib/session";
@@ -33,10 +34,14 @@ import { requireSession } from "@/lib/session";
 describe("requireSession", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetEnv.mockReturnValue({
+      AUTH_MODE: "service_account",
+      BETTER_AUTH_SECRET: "mock-secret",
+    });
   });
 
   it("returns session when getSession succeeds", async () => {
-    const mockSession = { user: { id: "u1" } };
+    const mockSession = { user: { id: "u1", email: "user@example.com" } };
     mockGetSession.mockResolvedValue(mockSession);
 
     const session = await requireSession();
@@ -64,5 +69,35 @@ describe("requireSession", () => {
     const session = await requireSession();
     expect(session).toBeNull();
     expect(mockCookies.delete).not.toHaveBeenCalled();
+  });
+
+  describe("in user_oauth mode", () => {
+    beforeEach(() => {
+      mockGetEnv.mockReturnValue({
+        AUTH_MODE: "user_oauth",
+        BETTER_AUTH_SECRET: "mock-secret",
+      });
+    });
+
+    it("returns session when getSession succeeds with a normal user email", async () => {
+      const mockSession = { user: { id: "u1", email: "admin@company.com" } };
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const session = await requireSession();
+      expect(session).toBe(mockSession);
+      expect(mockCookies.delete).not.toHaveBeenCalled();
+    });
+
+    it("invalidates session and deletes cookies when session is anonymous (service-account.local)", async () => {
+      const mockSession = { user: { id: "u1", email: "anon-123@service-account.local" } };
+      mockGetSession.mockResolvedValue(mockSession);
+      mockCookies.getAll.mockReturnValue([
+        { name: "better-auth.session_token", value: "anon-cookie-val" },
+      ]);
+
+      const session = await requireSession();
+      expect(session).toBeNull();
+      expect(mockCookies.delete).toHaveBeenCalledWith("better-auth.session_token");
+    });
   });
 });

--- a/mcp-examples/pocket-cep/src/components/auth-health-provider.tsx
+++ b/mcp-examples/pocket-cep/src/components/auth-health-provider.tsx
@@ -52,30 +52,38 @@ export function AuthHealthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     function handler(event: Event) {
       const detail = (event as CustomEvent<AuthErrorPayload>).detail;
-      if (detail && detail.code === "unauthenticated" && mode.authMode === "service_account") {
-        console.warn(
-          "AuthHealthProvider: Stale session detected in Service Account mode. " +
-            "Attempting background silent refresh...",
-        );
-        fetch("/api/auth/auto-session", {
-          headers: { Accept: "application/json" },
-        })
-          .then((res) => {
-            if (res.ok) {
-              console.log("AuthHealthProvider: Silent session refresh succeeded.");
-              clear();
-            } else {
-              console.error(
-                `AuthHealthProvider: Silent refresh failed with status ${res.status}. ` +
-                  "Fallback to hard redirect.",
-              );
-              window.location.href = "/api/auth/auto-session";
-            }
+      if (detail && detail.code === "unauthenticated") {
+        if (mode.authMode === "service_account") {
+          console.warn(
+            "AuthHealthProvider: Stale session detected in Service Account mode. " +
+              "Attempting background silent refresh...",
+          );
+          fetch("/api/auth/auto-session", {
+            headers: { Accept: "application/json" },
           })
-          .catch((err) => {
-            console.error("AuthHealthProvider: Silent refresh network error:", err);
-            window.location.href = "/api/auth/auto-session";
-          });
+            .then((res) => {
+              if (res.ok) {
+                console.log("AuthHealthProvider: Silent session refresh succeeded.");
+                clear();
+              } else {
+                console.error(
+                  `AuthHealthProvider: Silent refresh failed with status ${res.status}. ` +
+                    "Fallback to hard redirect.",
+                );
+                window.location.href = "/api/auth/auto-session";
+              }
+            })
+            .catch((err) => {
+              console.error("AuthHealthProvider: Silent refresh network error:", err);
+              window.location.href = "/api/auth/auto-session";
+            });
+        } else {
+          console.warn(
+            "AuthHealthProvider: Stale session detected in User OAuth mode. " +
+              "Redirecting to login page.",
+          );
+          window.location.href = "/";
+        }
       } else if (detail && typeof detail.code === "string") {
         setError(detail);
       }

--- a/mcp-examples/pocket-cep/src/components/chat-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/chat-panel.tsx
@@ -27,6 +27,7 @@ import type { InvocationPart } from "@/lib/tool-part";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { getModelById } from "@/lib/models";
 import { buildByokHeader, getStoredModelId } from "@/lib/model-preferences";
+import { authAwareFetch } from "@/lib/auth-aware-fetch";
 
 type ChatPanelProps = {
   selectedUser: string;
@@ -96,6 +97,7 @@ export function ChatPanel({ selectedUser, onToolInvocation, onClearSelectedUser 
         api: "/api/chat",
         body: resolveBody,
         headers: resolveHeaders,
+        fetch: authAwareFetch,
       }),
     [resolveBody, resolveHeaders],
   );
@@ -111,7 +113,7 @@ export function ChatPanel({ selectedUser, onToolInvocation, onClearSelectedUser 
       try {
         const body = resolveBody();
         const headers = { ...resolveHeaders(), "Content-Type": "application/json" };
-        const res = await fetch("/api/chat/suggestions", {
+        const res = await authAwareFetch("/api/chat/suggestions", {
           method: "POST",
           headers,
           body: JSON.stringify({ ...body, messages: currentMessages }),
@@ -224,7 +226,7 @@ export function ChatPanel({ selectedUser, onToolInvocation, onClearSelectedUser 
       if (promptExpanding || isStreaming) return;
       setPromptExpanding(prompt.name);
       try {
-        const res = await fetch("/api/prompts", {
+        const res = await authAwareFetch("/api/prompts", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name: prompt.name }),

--- a/mcp-examples/pocket-cep/src/lib/session.ts
+++ b/mcp-examples/pocket-cep/src/lib/session.ts
@@ -13,6 +13,8 @@
 
 import { headers, cookies } from "next/headers";
 import { getAuth } from "./auth";
+import { getEnv } from "./env";
+import { SA_EMAIL_DOMAIN } from "./constants";
 
 /**
  * Resolves the current BetterAuth session or null. Reads cookies from
@@ -22,24 +24,42 @@ import { getAuth } from "./auth";
  * If the session is invalid but session cookies are still present in the
  * browser (e.g. after key rotation or switching environments), they are
  * cleared automatically to prevent redirect loops.
+ *
+ * It also invalidates and clears anonymous sessions if the app has been
+ * switched to `user_oauth` mode.
  */
 export async function requireSession() {
   const auth = getAuth();
   const session = await auth.api.getSession({ headers: await headers() });
+  
+  let isStaleAnonymous = false;
+  try {
+    const config = getEnv();
+    isStaleAnonymous = Boolean(
+      session &&
+        config.AUTH_MODE === "user_oauth" &&
+        session.user.email?.endsWith(`@${SA_EMAIL_DOMAIN}`),
+    );
+  } catch {
+    // If env cannot be loaded, fallback to safe false
+  }
 
-  if (!session) {
+  if (!session || isStaleAnonymous) {
     const cookieStore = await cookies();
     // Better Auth session cookie names contain "session_token"
     const sessionCookies = cookieStore.getAll().filter((c) => c.name.includes("session_token"));
     if (sessionCookies.length > 0) {
       console.warn(
-        "requireSession: Invalid session but session cookies present. Clearing stale cookies:",
+        `requireSession: ${
+          isStaleAnonymous ? "Stale anonymous session in OAuth mode" : "Invalid session"
+        }. Clearing stale cookies:`,
         sessionCookies.map((c) => c.name),
       );
       for (const cookie of sessionCookies) {
         cookieStore.delete(cookie.name);
       }
     }
+    return null;
   }
 
   return session;


### PR DESCRIPTION
Resolves the issue where switching to User OAuth mode with a stale session cookie from a previous setup leaves the user on a broken dashboard showing 401s, instead of redirecting them to the login page. Also closes a gap where auth errors during chat interactions didn't trigger recovery.

### What
- **OAuth Auto-Redirect**: Updated `AuthHealthProvider` in `src/components/auth-health-provider.tsx` to check for `"unauthenticated"` errors in `user_oauth` mode. If detected, it now automatically redirects the browser to `/` (the landing page with the Google Sign-In card).
- **Chat Interception**: Updated `ChatPanel` in `src/components/chat-panel.tsx` to use `authAwareFetch` for:
  - The Vercel AI SDK `DefaultChatTransport` (`fetch` option).
  - Suggestions fetches (`/api/chat/suggestions`).
  - Prompts expansion fetches (`/api/prompts`).

### Why
- **OAuth Recovery**: Unlike Service Account mode, background recovery is not possible in User OAuth mode because it requires user interaction to sign in again. Currently, the proxy only redirects to `/` if the cookie is missing. If it's present but invalid (stale), the proxy lets the user pass to `/dashboard`, and the subsequent API calls clear the cookie on the server. However, the client-side UI stayed on `/dashboard` showing 401s until a manual page reload. This change ensures that the moment the client receives the first 401 (and the cookie is cleared), the browser is immediately redirected to the login page.
- **Closing the Chat Gap**: Previously, `DefaultChatTransport` and suggestions/prompts fetches used standard `fetch`. If a session expired *while* the user was chatting, these requests would return 401 but fail silently without triggering the auth-health provider's recovery flow. By switching them to `authAwareFetch`, any auth failure during chat interactions now correctly triggers either silent refresh (in SA mode) or redirection to login (in OAuth mode).