### PR TITLE
fix: force customerId scope gating in tools and prompt expansions

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/unit/mcp-client.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/mcp-client.test.ts
@@ -10,10 +10,19 @@
  * running server.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockGetActiveCustomerId } = vi.hoisted(() => ({
+  mockGetActiveCustomerId: vi.fn(),
+}));
+
+vi.mock("@/lib/sa-session", () => ({
+  getActiveCustomerId: mockGetActiveCustomerId,
+}));
 
 const mockCallTool = vi.fn();
 const mockListTools = vi.fn();
+const mockGetPrompt = vi.fn();
 const mockConnect = vi.fn();
 const mockClientClose = vi.fn();
 const mockTransportClose = vi.fn();
@@ -26,6 +35,7 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
       connect: mockConnect,
       callTool: mockCallTool,
       listTools: mockListTools,
+      getPrompt: mockGetPrompt,
       close: mockClientClose,
     };
   }),
@@ -38,7 +48,7 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
 }));
 
 // Import after mocks are set up.
-import { callMcpTool, listMcpTools } from "@/lib/mcp-client";
+import { callMcpTool, listMcpTools, getMcpPrompt } from "@/lib/mcp-client";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 describe("callMcpTool", () => {
@@ -100,6 +110,48 @@ describe("callMcpTool", () => {
 
     expect(mockClientClose).toHaveBeenCalled();
   });
+
+  describe("service_account mode gating", () => {
+    const originalAuthMode = process.env.AUTH_MODE;
+
+    beforeEach(() => {
+      process.env.AUTH_MODE = "service_account";
+      mockGetActiveCustomerId.mockResolvedValue("C0111111");
+    });
+
+    afterEach(() => {
+      process.env.AUTH_MODE = originalAuthMode;
+    });
+
+    it("overwrites the customerId tool argument with the session customerId", async () => {
+      await callMcpTool("http://localhost:3000/mcp", "list_dlp_rules", {
+        customerId: "ATTACKER-TENANT-ID",
+        filter: "active",
+      });
+
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: "list_dlp_rules",
+        arguments: {
+          customerId: "C0111111",
+          filter: "active",
+        },
+      });
+    });
+
+    it("injects the customerId if it is missing", async () => {
+      await callMcpTool("http://localhost:3000/mcp", "list_dlp_rules", {
+        filter: "active",
+      });
+
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: "list_dlp_rules",
+        arguments: {
+          customerId: "C0111111",
+          filter: "active",
+        },
+      });
+    });
+  });
 });
 
 describe("listMcpTools", () => {
@@ -133,5 +185,78 @@ describe("listMcpTools", () => {
 
     // The second tool had no inputSchema — should get a default.
     expect(tools[1].inputSchema).toEqual({ type: "object", properties: {} });
+  });
+});
+
+describe("getMcpPrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPrompt.mockResolvedValue({
+      messages: [{ role: "user", content: { type: "text", text: "Prompt expanded text" } }],
+    });
+  });
+
+  it("calls the correct prompt with arguments", async () => {
+    const res = await getMcpPrompt("http://localhost:3000/mcp", "cep:health", { foo: "bar" });
+    expect(mockGetPrompt).toHaveBeenCalledWith({
+      name: "cep:health",
+      arguments: { foo: "bar" },
+    });
+    expect(res).toHaveLength(1);
+    expect(res[0].content.type).toBe("text");
+    expect((res[0].content as { text: string }).text).toBe("Prompt expanded text");
+  });
+
+  describe("service_account mode gating", () => {
+    const originalAuthMode = process.env.AUTH_MODE;
+
+    beforeEach(() => {
+      process.env.AUTH_MODE = "service_account";
+      mockGetActiveCustomerId.mockResolvedValue("C0111111");
+    });
+
+    afterEach(() => {
+      process.env.AUTH_MODE = originalAuthMode;
+    });
+
+    it("overwrites the customerId prompt argument with the session customerId", async () => {
+      await getMcpPrompt("http://localhost:3000/mcp", "cep:health", {
+        customerId: "ATTACKER-TENANT-ID",
+        foo: "bar",
+      });
+
+      expect(mockGetPrompt).toHaveBeenCalledWith({
+        name: "cep:health",
+        arguments: {
+          customerId: "C0111111",
+          foo: "bar",
+        },
+      });
+    });
+
+    it("injects the customerId if it is missing", async () => {
+      await getMcpPrompt("http://localhost:3000/mcp", "cep:health", {
+        foo: "bar",
+      });
+
+      expect(mockGetPrompt).toHaveBeenCalledWith({
+        name: "cep:health",
+        arguments: {
+          customerId: "C0111111",
+          foo: "bar",
+        },
+      });
+    });
+
+    it("handles undefined args gracefully", async () => {
+      await getMcpPrompt("http://localhost:3000/mcp", "cep:health", undefined);
+
+      expect(mockGetPrompt).toHaveBeenCalledWith({
+        name: "cep:health",
+        arguments: {
+          customerId: "C0111111",
+        },
+      });
+    });
   });
 });

--- a/mcp-examples/pocket-cep/src/__tests__/unit/mcp-client.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/mcp-client.test.ts
@@ -151,6 +151,32 @@ describe("callMcpTool", () => {
         },
       });
     });
+
+    it("deletes user-supplied customerId if session has no active customerId", async () => {
+      mockGetActiveCustomerId.mockResolvedValue(undefined);
+
+      await callMcpTool("http://localhost:3000/mcp", "list_dlp_rules", {
+        customerId: "ATTACKER-TENANT-ID",
+        filter: "active",
+      });
+
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: "list_dlp_rules",
+        arguments: {
+          filter: "active",
+        },
+      });
+    });
+
+    it("throws if getActiveCustomerId throws an error", async () => {
+      mockGetActiveCustomerId.mockRejectedValue(new Error("Decryption failed"));
+
+      await expect(
+        callMcpTool("http://localhost:3000/mcp", "list_dlp_rules", {
+          customerId: "ATTACKER-TENANT-ID",
+        }),
+      ).rejects.toThrow("Failed to resolve active customer ID for scope gating: Decryption failed");
+    });
   });
 });
 
@@ -257,6 +283,32 @@ describe("getMcpPrompt", () => {
           customerId: "C0111111",
         },
       });
+    });
+
+    it("deletes user-supplied customerId if session has no active customerId", async () => {
+      mockGetActiveCustomerId.mockResolvedValue(undefined);
+
+      await getMcpPrompt("http://localhost:3000/mcp", "cep:health", {
+        customerId: "ATTACKER-TENANT-ID",
+        foo: "bar",
+      });
+
+      expect(mockGetPrompt).toHaveBeenCalledWith({
+        name: "cep:health",
+        arguments: {
+          foo: "bar",
+        },
+      });
+    });
+
+    it("throws if getActiveCustomerId throws an error", async () => {
+      mockGetActiveCustomerId.mockRejectedValue(new Error("Decryption failed"));
+
+      await expect(
+        getMcpPrompt("http://localhost:3000/mcp", "cep:health", {
+          customerId: "ATTACKER-TENANT-ID",
+        }),
+      ).rejects.toThrow("Failed to resolve active customer ID for scope gating: Decryption failed");
     });
   });
 });

--- a/mcp-examples/pocket-cep/src/lib/mcp-client.ts
+++ b/mcp-examples/pocket-cep/src/lib/mcp-client.ts
@@ -123,8 +123,14 @@ export async function callMcpTool(
       const customerId = await getActiveCustomerId();
       if (customerId) {
         callArgs.customerId = customerId;
+      } else {
+        delete callArgs.customerId;
       }
-    } catch {}
+    } catch (error) {
+      throw new Error(
+        `Failed to resolve active customer ID for scope gating: ${getErrorMessage(error)}`,
+      );
+    }
   }
 
   const rawRequest = {
@@ -232,8 +238,14 @@ export async function getMcpPrompt(
       const customerId = await getActiveCustomerId();
       if (customerId) {
         callArgs.customerId = customerId;
+      } else {
+        delete callArgs.customerId;
       }
-    } catch {}
+    } catch (error) {
+      throw new Error(
+        `Failed to resolve active customer ID for scope gating: ${getErrorMessage(error)}`,
+      );
+    }
   }
 
   const { client } = await connect(serverUrl, accessToken);

--- a/mcp-examples/pocket-cep/src/lib/mcp-client.ts
+++ b/mcp-examples/pocket-cep/src/lib/mcp-client.ts
@@ -118,10 +118,7 @@ export async function callMcpTool(
   accessToken?: string,
 ): Promise<McpToolResult> {
   const callArgs: Record<string, unknown> = { ...args };
-  if (
-    process.env.AUTH_MODE === "service_account" &&
-    (!callArgs.customerId || callArgs.customerId === "my_customer")
-  ) {
+  if (process.env.AUTH_MODE === "service_account") {
     try {
       const customerId = await getActiveCustomerId();
       if (customerId) {
@@ -229,10 +226,20 @@ export async function getMcpPrompt(
 ): Promise<PromptMessage[]> {
   console.log(LOG_TAGS.MCP, `Expanding prompt: ${name}`);
 
+  const callArgs = args ? { ...args } : {};
+  if (process.env.AUTH_MODE === "service_account") {
+    try {
+      const customerId = await getActiveCustomerId();
+      if (customerId) {
+        callArgs.customerId = customerId;
+      }
+    } catch {}
+  }
+
   const { client } = await connect(serverUrl, accessToken);
 
   try {
-    const result = await client.getPrompt({ name, arguments: args });
+    const result = await client.getPrompt({ name, arguments: callArgs });
     return result.messages;
   } finally {
     await client.close();


### PR DESCRIPTION
### MOTIVATION
In `service_account` mode, the backend Service Account has broad GCP IAM permissions and can access multiple Workspace domains. Previously, if the administrator manually provided a different `customerId` in their chat request, the LLM would propagate that parameter down to the tool calls, allowing the admin to query unauthorized tenants. We need to enforce a hard boundary so the agent can only operate within the tenant selected on the UI login screen.

### MAIN CHANGES
* **Unconditional Gating**: Refactored `callMcpTool` and `getMcpPrompt` in `src/lib/mcp-client.ts` to unconditionally force-overwrite the `customerId` argument with the active customer ID retrieved from the signed session cookie.
* **Review Fixes**: Added fail-fast protection. If resolving the session `customerId` throws an error (e.g. cookie decryption fails or JWT is tampered), the client now throws a wrapped exception and aborts execution immediately instead of silently swallowing the error and allowing the request to proceed.
* **Safe Fallback**: If the session has no active `customerId` configured, we explicitly delete the client-provided `customerId` argument to block unauthenticated scope overrides.
* **Test Coverage**: Added unit tests in `mcp-client.test.ts` to cover parameter overwriting, argument stripping, and fail-fast behavior.

### DESIGN DECISIONS
* We chose to perform this gating at the lowest client boundary (`mcp-client.ts`) rather than in individual tool definitions or route handlers. This provides a centralized bottleneck that protects all current and future tools/prompts from scope bypasses.

TAG=agy
CONV=b3471264-2592-4924-b031-267b4bf62326
