### PR TITLE
perf: partition Service Account token cache to avoid multi-tenant thrashing

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/unit/access-token.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/unit/access-token.test.ts
@@ -169,6 +169,52 @@ describe("mintServiceAccountTokenOrThrow", () => {
     expect(mockAuthorize).not.toHaveBeenCalled();
   });
 
+  it("mints separate tokens for different subjects and caches them concurrently", async () => {
+    mockLoadSaKey.mockResolvedValue({
+      key: { client_email: "svc@example.com", private_key: "fake-key" },
+      source: "test.json",
+      errors: [],
+    });
+
+    // First call for Admin A
+    mockAuthorize.mockResolvedValueOnce({ token: "jwt-token-admin-a" });
+    const tokenA1 = await mintServiceAccountTokenOrThrow("admin-a@domain.com");
+    expect(tokenA1).toBe("jwt-token-admin-a");
+
+    // Second call for Admin B
+    mockAuthorize.mockResolvedValueOnce({ token: "jwt-token-admin-b" });
+    const tokenB1 = await mintServiceAccountTokenOrThrow("admin-b@domain.com");
+    expect(tokenB1).toBe("jwt-token-admin-b");
+
+    // Assert cache hit for Admin A
+    mockAuthorize.mockClear();
+    const tokenA2 = await mintServiceAccountTokenOrThrow("admin-a@domain.com");
+    expect(tokenA2).toBe("jwt-token-admin-a");
+
+    // Assert cache hit for Admin B
+    const tokenB2 = await mintServiceAccountTokenOrThrow("admin-b@domain.com");
+    expect(tokenB2).toBe("jwt-token-admin-b");
+
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
+  it("clearing cache invalidates all cached subjects", async () => {
+    mockLoadSaKey.mockResolvedValue({
+      key: { client_email: "svc@example.com", private_key: "fake-key" },
+      source: "test.json",
+      errors: [],
+    });
+    mockAuthorize.mockResolvedValueOnce({ token: "jwt-token-a" });
+    await mintServiceAccountTokenOrThrow("admin-a@domain.com");
+
+    clearServiceAccountTokenCache();
+
+    // Call again should trigger another mint
+    mockAuthorize.mockResolvedValueOnce({ token: "jwt-token-a-new" });
+    const tokenANew = await mintServiceAccountTokenOrThrow("admin-a@domain.com");
+    expect(tokenANew).toBe("jwt-token-a-new");
+  });
+
   it("getServiceAccountAccessToken returns undefined gracefully on mint failure", async () => {
     mockLoadSaKey.mockResolvedValue(null);
     const token = await getServiceAccountAccessToken("admin@example.com");

--- a/mcp-examples/pocket-cep/src/lib/access-token.ts
+++ b/mcp-examples/pocket-cep/src/lib/access-token.ts
@@ -130,11 +130,12 @@ type CachedSaToken = {
   subject?: string;
 };
 
-let saTokenCache: CachedSaToken | null = null;
+const saTokenCacheMap = new Map<string, CachedSaToken>();
+const DIRECT_CACHE_KEY = "__direct__";
 const SAFETY_BUFFER_MS = 5 * 60 * 1000; // 5 minutes safety buffer
 
 export function clearServiceAccountTokenCache(): void {
-  saTokenCache = null;
+  saTokenCacheMap.clear();
 }
 
 /**
@@ -143,13 +144,11 @@ export function clearServiceAccountTokenCache(): void {
  */
 export async function mintServiceAccountTokenOrThrow(impersonatedUser?: string): Promise<string> {
   const subject = impersonatedUser || undefined;
+  const cacheKey = impersonatedUser || DIRECT_CACHE_KEY;
 
-  if (
-    saTokenCache &&
-    saTokenCache.subject === subject &&
-    Date.now() < saTokenCache.expiresAt - SAFETY_BUFFER_MS
-  ) {
-    return saTokenCache.token;
+  const cached = saTokenCacheMap.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt - SAFETY_BUFFER_MS) {
+    return cached.token;
   }
 
   const loaded = await loadServiceAccountKey();
@@ -216,11 +215,11 @@ export async function mintServiceAccountTokenOrThrow(impersonatedUser?: string):
     }
   }
 
-  saTokenCache = {
+  saTokenCacheMap.set(cacheKey, {
     token: res.token,
     expiresAt,
     subject,
-  };
+  });
 
   return res.token;
 }


### PR DESCRIPTION
### MOTIVATION
Google Workspace access tokens minted for Service Accounts were stored in a single global variable. In multi-tenant environments, administrators representing different customer domains concurrently using the app would constantly overwrite this global cache slot. This cache thrashing forced every API request to incur a 500ms+ network delay while fetching a new token from Google, causing latency spikes and risking Google API rate limit bans.

### MAIN CHANGES
* **Cache Map Partitioning**: Refactored the `saTokenCache` variable in `src/lib/access-token.ts` into a `Map<string, CachedSaToken>()` keyed by the impersonated subject's email (using `__direct__` as the key for non-impersonated sessions).
* **Minter Updates**: Updated `mintServiceAccountTokenOrThrow` to read and write tokens using the subject-specific map keys.
* **Cache Clearing**: Refactored `clearServiceAccountTokenCache` to clear the map.
* **Unit Tests**: Added concurrent caching tests in `access-token.test.ts` to assert that multiple target subjects can cache separate tokens simultaneously without collisions or invalidation.

### DESIGN DECISIONS
* We kept the memory cache in-process rather than introducing Redis or Memcached because the application is designed to be lightweight and simple to deploy. A `Map` provides sufficient isolation within a single Node process.

TAG=agy
CONV=b3471264-2592-4924-b031-267b4bf62326
