### PR TITLE
feat: implement MCP Server Registry sidebar tab

### DIFF
--- a/mcp-examples/pocket-cep/src/__tests__/integration/api/mcp-registry.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/integration/api/mcp-registry.test.ts
@@ -11,6 +11,7 @@ const {
   mockListMcpTools,
   mockListMcpPrompts,
   mockGetMcpPrompt,
+  mockGetActiveCustomerId,
 } = vi.hoisted(() => ({
   mockRequireSession: vi.fn(),
   mockGetGoogleAccessToken: vi.fn(),
@@ -18,6 +19,7 @@ const {
   mockListMcpTools: vi.fn(),
   mockListMcpPrompts: vi.fn(),
   mockGetMcpPrompt: vi.fn(),
+  mockGetActiveCustomerId: vi.fn(),
 }));
 
 vi.mock("@/lib/session", () => ({
@@ -30,6 +32,10 @@ vi.mock("@/lib/access-token", () => ({
 
 vi.mock("@/lib/env", () => ({
   getEnv: mockGetEnv,
+}));
+
+vi.mock("@/lib/sa-session", () => ({
+  getActiveCustomerId: mockGetActiveCustomerId,
 }));
 
 vi.mock("@/lib/mcp-client", () => ({
@@ -48,6 +54,7 @@ describe("MCP Registry Endpoints", () => {
     clearCache();
     mockRequireSession.mockResolvedValue(true);
     mockGetGoogleAccessToken.mockResolvedValue("mock-token");
+    mockGetActiveCustomerId.mockResolvedValue("mock-customer-id");
     mockGetEnv.mockReturnValue({ MCP_SERVER_URL: "http://localhost:4000/mcp" });
   });
 

--- a/mcp-examples/pocket-cep/src/__tests__/integration/api/mcp-registry.test.ts
+++ b/mcp-examples/pocket-cep/src/__tests__/integration/api/mcp-registry.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @file Integration tests for MCP Registry endpoints (/api/tools and /api/prompts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockRequireSession,
+  mockGetGoogleAccessToken,
+  mockGetEnv,
+  mockListMcpTools,
+  mockListMcpPrompts,
+  mockGetMcpPrompt,
+} = vi.hoisted(() => ({
+  mockRequireSession: vi.fn(),
+  mockGetGoogleAccessToken: vi.fn(),
+  mockGetEnv: vi.fn(),
+  mockListMcpTools: vi.fn(),
+  mockListMcpPrompts: vi.fn(),
+  mockGetMcpPrompt: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({
+  requireSession: mockRequireSession,
+}));
+
+vi.mock("@/lib/access-token", () => ({
+  getGoogleAccessToken: mockGetGoogleAccessToken,
+}));
+
+vi.mock("@/lib/env", () => ({
+  getEnv: mockGetEnv,
+}));
+
+vi.mock("@/lib/mcp-client", () => ({
+  listMcpTools: mockListMcpTools,
+  listMcpPrompts: mockListMcpPrompts,
+  getMcpPrompt: mockGetMcpPrompt,
+}));
+
+import { GET as getTools } from "@/app/api/tools/route";
+import { GET as getPrompts, POST as postPrompts } from "@/app/api/prompts/route";
+import { clearCache } from "@/lib/server-cache";
+
+describe("MCP Registry Endpoints", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCache();
+    mockRequireSession.mockResolvedValue(true);
+    mockGetGoogleAccessToken.mockResolvedValue("mock-token");
+    mockGetEnv.mockReturnValue({ MCP_SERVER_URL: "http://localhost:4000/mcp" });
+  });
+
+  describe("GET /api/tools", () => {
+    it("returns 401 when unauthenticated", async () => {
+      mockRequireSession.mockResolvedValue(false);
+      const res = await getTools();
+      expect(res.status).toBe(401);
+    });
+
+    it("returns list of tools on success", async () => {
+      const mockTools = [
+        {
+          name: "test_tool",
+          description: "A test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ];
+      mockListMcpTools.mockResolvedValue(mockTools);
+
+      const res = await getTools();
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toEqual({ tools: mockTools });
+      expect(mockListMcpTools).toHaveBeenCalledWith("http://localhost:4000/mcp", "mock-token");
+    });
+  });
+
+  describe("GET /api/prompts", () => {
+    it("returns 401 when unauthenticated", async () => {
+      mockRequireSession.mockResolvedValue(false);
+      const res = await getPrompts();
+      expect(res.status).toBe(401);
+    });
+
+    it("returns list of prompts on success", async () => {
+      const mockPrompts = [
+        {
+          name: "test_prompt",
+          description: "A test prompt",
+          arguments: [],
+        },
+      ];
+      mockListMcpPrompts.mockResolvedValue(mockPrompts);
+
+      const res = await getPrompts();
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toEqual({ prompts: mockPrompts });
+      expect(mockListMcpPrompts).toHaveBeenCalledWith("http://localhost:4000/mcp", "mock-token");
+    });
+  });
+
+  describe("POST /api/prompts", () => {
+    it("returns 401 when unauthenticated", async () => {
+      mockRequireSession.mockResolvedValue(false);
+      const req = new Request("http://localhost/api/prompts", {
+        method: "POST",
+        body: JSON.stringify({ name: "test_prompt" }),
+      });
+      const res = await postPrompts(req);
+      expect(res.status).toBe(401);
+    });
+
+    it("returns bad request when name is missing", async () => {
+      const req = new Request("http://localhost/api/prompts", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+      const res = await postPrompts(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("expands prompt messages on success", async () => {
+      const mockExpandedMessages = [
+        {
+          role: "user",
+          content: { type: "text", text: "Expanded prompt text content" },
+        },
+      ];
+      mockGetMcpPrompt.mockResolvedValue(mockExpandedMessages);
+
+      const req = new Request("http://localhost/api/prompts", {
+        method: "POST",
+        body: JSON.stringify({ name: "test_prompt", args: { param: "value" } }),
+      });
+      const res = await postPrompts(req);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toEqual({ text: "Expanded prompt text content" });
+      expect(mockGetMcpPrompt).toHaveBeenCalledWith(
+        "http://localhost:4000/mcp",
+        "test_prompt",
+        { param: "value" },
+        "mock-token",
+      );
+    });
+  });
+});

--- a/mcp-examples/pocket-cep/src/app/dashboard/dashboard-client.tsx
+++ b/mcp-examples/pocket-cep/src/app/dashboard/dashboard-client.tsx
@@ -181,7 +181,7 @@ function DashboardShell() {
               isActive={sidebarTab === "registry"}
               onSelect={() => setSidebarTab("registry")}
               icon={BookOpen}
-              label="Registry"
+              label="MCP Server Registry"
             />
           </div>
 
@@ -330,20 +330,21 @@ function SidebarTabButton({
       aria-controls={panelId}
       tabIndex={isActive ? 0 : -1}
       onClick={onSelect}
+      title={label}
+      aria-label={label}
       className={cn(
-        "state-layer flex flex-1 items-center justify-center gap-1.5 rounded-[var(--radius-xs)] px-2 py-1.5 text-xs font-medium",
+        "state-layer relative flex h-9 flex-1 items-center justify-center gap-1.5 rounded-[var(--radius-xs)] py-2 text-xs font-medium",
         isActive
           ? "bg-primary-light text-primary"
-          : "text-on-surface-variant hover:text-on-surface",
+          : "text-on-surface-variant hover:text-on-surface hover:bg-on-surface/5",
       )}
     >
-      <Icon className="size-3.5" aria-hidden="true" />
-      <span>{label}</span>
+      <Icon className="animate-fade-in size-4" aria-hidden="true" />
       {typeof count === "number" && count > 0 && (
         <span
           className={cn(
-            "rounded-full px-1.5 py-0.5 text-[0.625rem] tabular-nums",
-            isActive ? "bg-primary text-on-primary" : "bg-surface-dim text-on-surface-variant",
+            "absolute -top-0.5 -right-0.5 scale-90 rounded-full px-1.5 py-0.5 text-[0.625rem] leading-none font-bold",
+            isActive ? "bg-primary text-on-primary" : "bg-error text-on-error animate-pulse",
           )}
         >
           {count}

--- a/mcp-examples/pocket-cep/src/app/dashboard/dashboard-client.tsx
+++ b/mcp-examples/pocket-cep/src/app/dashboard/dashboard-client.tsx
@@ -23,7 +23,9 @@ import type { InvocationPart } from "@/lib/tool-part";
 import type { ActivityMap } from "@/lib/activity-data";
 import { SIDEBAR_COLLAPSED_KEY, USER_SEARCH_INPUT_ID } from "@/lib/constants";
 import { usePersistedString } from "@/lib/storage";
-import { Activity, ChevronLeft, ChevronRight, Eraser, Wrench } from "lucide-react";
+import { Activity, BookOpen, ChevronLeft, ChevronRight, Eraser, Wrench } from "lucide-react";
+import { RegistryPanel } from "@/components/registry-panel";
+import type { Prompt } from "@/components/registry-panel";
 
 /**
  * Response shape returned by `GET /api/users/activity`.
@@ -35,7 +37,7 @@ type ActivityResponse = { activity?: ActivityMap };
  * as state on the dashboard so other surfaces (e.g. a future "open
  * inspector on tool call" affordance) can flip the active tab.
  */
-type SidebarTab = "activity" | "inspector";
+type SidebarTab = "activity" | "inspector" | "registry";
 
 /**
  * Props provided by the RSC wrapper.
@@ -63,6 +65,7 @@ function DashboardShell() {
   const [selectedUser, setSelectedUser] = useState("");
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>("activity");
   const [toolInvocations, setToolInvocations] = useState<InvocationPart[]>([]);
+  const [pendingPrompt, setPendingPrompt] = useState<Prompt | null>(null);
 
   /**
    * SWR handles deduping, focus revalidation, and persistent localStorage
@@ -172,10 +175,18 @@ function DashboardShell() {
               label="MCP Inspector"
               count={toolInvocations.length}
             />
+            <SidebarTabButton
+              id="tab-registry"
+              panelId="panel-registry"
+              isActive={sidebarTab === "registry"}
+              onSelect={() => setSidebarTab("registry")}
+              icon={BookOpen}
+              label="Registry"
+            />
           </div>
 
           <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-            {sidebarTab === "activity" ? (
+            {sidebarTab === "activity" && (
               <section
                 id="panel-activity"
                 role="tabpanel"
@@ -203,7 +214,9 @@ function DashboardShell() {
                   onPick={setSelectedUser}
                 />
               </section>
-            ) : (
+            )}
+
+            {sidebarTab === "inspector" && (
               <section
                 id="panel-inspector"
                 role="tabpanel"
@@ -217,6 +230,15 @@ function DashboardShell() {
                   </span>
                 </header>
                 <InspectorList invocations={toolInvocations} />
+              </section>
+            )}
+
+            {sidebarTab === "registry" && (
+              <section id="panel-registry" role="tabpanel" aria-labelledby="tab-registry">
+                <RegistryPanel
+                  onExecutePrompt={(prompt) => setPendingPrompt(prompt)}
+                  isBusy={false}
+                />
               </section>
             )}
           </div>
@@ -247,6 +269,8 @@ function DashboardShell() {
 
           <ChatPanel
             selectedUser={selectedUser}
+            pendingPrompt={pendingPrompt}
+            onPromptExecuted={() => setPendingPrompt(null)}
             onToolInvocation={handleToolInvocation}
             onClearSelectedUser={() => setSelectedUser("")}
           />

--- a/mcp-examples/pocket-cep/src/components/chat-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/chat-panel.tsx
@@ -19,14 +19,23 @@ import type { InvocationPart } from "@/lib/tool-part";
 import { getModelById } from "@/lib/models";
 import { buildByokHeader, getStoredModelId } from "@/lib/model-preferences";
 import { authAwareFetch } from "@/lib/auth-aware-fetch";
+import type { Prompt } from "./registry-panel";
 
 type ChatPanelProps = {
   selectedUser: string;
+  pendingPrompt?: Prompt | null;
+  onPromptExecuted?: () => void;
   onToolInvocation?: (invocation: InvocationPart) => void;
   onClearSelectedUser?: () => void;
 };
 
-export function ChatPanel({ selectedUser, onToolInvocation, onClearSelectedUser }: ChatPanelProps) {
+export function ChatPanel({
+  selectedUser,
+  pendingPrompt,
+  onPromptExecuted,
+  onToolInvocation,
+  onClearSelectedUser,
+}: ChatPanelProps) {
   const [input, setInput] = useState("");
 
   const selectedUserRef = useRef(selectedUser);
@@ -173,6 +182,41 @@ export function ChatPanel({ selectedUser, onToolInvocation, onClearSelectedUser 
   const handleSubmit = () => {
     handleSend(input);
   };
+  const runPrompt = useCallback(
+    async (prompt: Prompt) => {
+      if (isStreaming) return;
+      try {
+        const res = await authAwareFetch("/api/prompts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: prompt.name }),
+        });
+        const body: { text?: string; error?: string } = await res.json();
+        if (!res.ok || !body.text) throw new Error(body.error ?? "Prompt expansion failed");
+        setLatestSuggestions(null);
+        await sendMessage({
+          text: body.text,
+          metadata: { promptName: prompt.name, promptTitle: prompt.title || prompt.name },
+        });
+        setInput("");
+        setIsPinnedToBottom(true);
+        chatInputRef.current?.focus();
+      } catch (e) {
+        console.error("Failed to run prompt:", e);
+      }
+    },
+    [isStreaming, sendMessage],
+  );
+
+  useEffect(() => {
+    if (pendingPrompt) {
+      const timer = setTimeout(() => {
+        void runPrompt(pendingPrompt);
+        onPromptExecuted?.();
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+  }, [pendingPrompt, runPrompt, onPromptExecuted]);
   const isEmpty = messages.length === 0;
   /**
    * Show the typing indicator for the entire streaming window, not

--- a/mcp-examples/pocket-cep/src/components/chat-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/chat-panel.tsx
@@ -163,10 +163,13 @@ export function ChatPanel({
     }
   }, [messages, onToolInvocation]);
 
+  const [promptError, setPromptError] = useState<string | null>(null);
+
   const handleSend = useCallback(
     (text: string) => {
       if (!text.trim()) return;
       setLatestSuggestions(null);
+      setPromptError(null);
       sendMessage({ text });
       setInput("");
       setIsPinnedToBottom(true);
@@ -185,6 +188,7 @@ export function ChatPanel({
   const runPrompt = useCallback(
     async (prompt: Prompt) => {
       if (isStreaming) return;
+      setPromptError(null);
       try {
         const res = await authAwareFetch("/api/prompts", {
           method: "POST",
@@ -203,6 +207,7 @@ export function ChatPanel({
         chatInputRef.current?.focus();
       } catch (e) {
         console.error("Failed to run prompt:", e);
+        setPromptError(e instanceof Error ? e.message : "Failed to run prompt");
       }
     },
     [isStreaming, sendMessage],
@@ -264,9 +269,9 @@ export function ChatPanel({
             )}
           </div>
 
-          {error && (
+          {(error || promptError) && (
             <div className="bg-error-light text-error ring-error/20 mx-auto mt-4 max-w-3xl rounded-[var(--radius-sm)] px-3 py-2 text-sm ring-1">
-              {error.message}
+              {error?.message ?? promptError}
             </div>
           )}
 

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -196,7 +196,16 @@ function PromptItem({
         </div>
 
         <div className="flex shrink-0 items-center gap-0.5">
-          {!hasRequiredArgs && (
+          {hasRequiredArgs ? (
+            <button
+              type="button"
+              disabled
+              title="This prompt requires arguments and cannot be executed directly from the sidebar. You can invoke it in chat by typing its name."
+              className="text-on-surface-variant/20 flex size-5 cursor-not-allowed items-center justify-center rounded-full"
+            >
+              <ArrowUpRight className="size-3.5" />
+            </button>
+          ) : (
             <button
               type="button"
               onClick={() => onRun(prompt)}

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -195,6 +195,17 @@ function PromptItem({
   );
 }
 
+function getTruncatedDescription(description?: string, limit = 120): string {
+  if (!description) return "";
+  const sentences = description.split(/(?<=[.!?])\s+/);
+  const firstSentence = sentences[0] || "";
+
+  if (firstSentence.length <= limit) {
+    return firstSentence;
+  }
+  return firstSentence.slice(0, limit).trim() + "...";
+}
+
 function ToolItem({ tool }: { tool: McpTool }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -203,6 +214,7 @@ function ToolItem({ tool }: { tool: McpTool }) {
   }, []);
 
   const hasSchema = !!tool.inputSchema?.properties;
+  const truncatedDesc = getTruncatedDescription(tool.description);
 
   return (
     <div className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col rounded-[var(--radius-sm)] border p-2.5">
@@ -231,7 +243,9 @@ function ToolItem({ tool }: { tool: McpTool }) {
       </div>
 
       {tool.description && (
-        <p className="text-on-surface-variant mt-1 text-[0.75rem] leading-4">{tool.description}</p>
+        <p className="text-on-surface-variant animate-fade-in mt-1 text-[0.75rem] leading-4 text-pretty">
+          {expanded ? tool.description : truncatedDesc}
+        </p>
       )}
 
       {expanded && tool.inputSchema?.properties && (

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -1,0 +1,242 @@
+/**
+ * @file Panel to list registered MCP Tools and Prompts.
+ *
+ * Displays tool definitions, input schemas, and prompts catalog retrieved
+ * from the MCP server. Helps the developer understand the active context
+ * injected into the LLM and run prompts directly from the sidebar.
+ */
+
+"use client";
+
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+import { ArrowUpRight, ChevronDown, ChevronRight, Terminal, Wrench } from "lucide-react";
+import { Skeleton } from "./ui/skeleton";
+import { authAwareFetch } from "@/lib/auth-aware-fetch";
+
+export type PromptArgument = {
+  name: string;
+  description?: string;
+  required?: boolean;
+};
+
+export type Prompt = {
+  name: string;
+  description?: string;
+  arguments?: PromptArgument[];
+  title?: string;
+};
+
+export type McpTool = {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    type: string;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+};
+
+type RegistryPanelProps = {
+  /** Callback to trigger execution of a selected prompt. */
+  onExecutePrompt: (prompt: Prompt) => void;
+  /** Whether the parent is currently streaming/busy. */
+  isBusy: boolean;
+};
+
+type ToolsResponse = { tools?: McpTool[] };
+type PromptsResponse = { prompts?: Prompt[]; error?: string };
+
+export function RegistryPanel({ onExecutePrompt, isBusy }: RegistryPanelProps) {
+  const { data: toolsData, isLoading: isToolsLoading } = useSWR<ToolsResponse>(
+    "/api/tools",
+    async (url: string) => {
+      const res = await authAwareFetch(url);
+      if (!res.ok) throw new Error("Failed to fetch tools");
+      return res.json();
+    },
+    { revalidateOnFocus: false },
+  );
+
+  const { data: promptsData, isLoading: isPromptsLoading } = useSWR<PromptsResponse>(
+    "/api/prompts",
+    async (url: string) => {
+      const res = await authAwareFetch(url);
+      if (!res.ok) throw new Error("Failed to fetch prompts");
+      return res.json();
+    },
+    { revalidateOnFocus: false, errorRetryCount: 1 },
+  );
+
+  const tools = toolsData?.tools ?? [];
+  const prompts = promptsData?.prompts ?? [];
+
+  if (isToolsLoading || isPromptsLoading) {
+    return (
+      <div className="flex flex-col gap-4 p-4">
+        <Skeleton className="h-6 w-24" />
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 px-4 py-4">
+      {/* Prompts Section */}
+      <section aria-label="Available Prompts" className="flex flex-col gap-3">
+        <header className="border-on-surface/10 flex items-baseline justify-between border-b pb-1.5">
+          <h2 className="text-on-surface text-sm font-medium">MCP Prompts</h2>
+          <span className="text-on-surface-muted font-mono text-[0.6875rem]">prompts/list</span>
+        </header>
+
+        {prompts.length === 0 ? (
+          <p className="text-on-surface-muted text-xs">No prompts registered on the server.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {prompts.map((prompt) => (
+              <li key={prompt.name}>
+                <PromptItem prompt={prompt} onRun={onExecutePrompt} isBusy={isBusy} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Tools Section */}
+      <section aria-label="Available Tools" className="flex flex-col gap-3">
+        <header className="border-on-surface/10 flex items-baseline justify-between border-b pb-1.5">
+          <h2 className="text-on-surface text-sm font-medium">MCP Tools</h2>
+          <span className="text-on-surface-muted font-mono text-[0.6875rem]">tools/list</span>
+        </header>
+
+        {tools.length === 0 ? (
+          <p className="text-on-surface-muted text-xs">No tools registered on the server.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {tools.map((tool) => (
+              <li key={tool.name}>
+                <ToolItem tool={tool} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function PromptItem({
+  prompt,
+  onRun,
+  isBusy,
+}: {
+  prompt: Prompt;
+  onRun: (prompt: Prompt) => void;
+  isBusy: boolean;
+}) {
+  const title = prompt.title || prompt.name.replace(/^[^:]+:/, "");
+  const cleanTitle = title.charAt(0).toUpperCase() + title.slice(1);
+  const hasRequiredArgs = prompt.arguments?.some((a) => a.required) ?? false;
+
+  return (
+    <div className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col gap-1 rounded-[var(--radius-sm)] border p-2.5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Terminal className="text-primary size-3.5 shrink-0" />
+          <span className="text-on-surface truncate text-xs font-semibold">{cleanTitle}</span>
+        </div>
+
+        {!hasRequiredArgs && (
+          <button
+            type="button"
+            onClick={() => onRun(prompt)}
+            disabled={isBusy}
+            title="Execute prompt in chat"
+            className="state-layer text-primary hover:bg-primary/5 flex size-5 cursor-pointer items-center justify-center rounded-full transition-colors disabled:opacity-40"
+          >
+            <ArrowUpRight className="size-3.5" />
+          </button>
+        )}
+      </div>
+
+      {prompt.description && (
+        <p className="text-on-surface-variant text-[0.75rem] leading-4">{prompt.description}</p>
+      )}
+
+      {prompt.arguments && prompt.arguments.length > 0 && (
+        <div className="border-on-surface/5 mt-1.5 flex flex-col gap-1 border-t pt-1.5">
+          <span className="text-on-surface-muted text-[0.625rem] font-bold tracking-wider uppercase">
+            Arguments
+          </span>
+          <div className="flex flex-col gap-1">
+            {prompt.arguments.map((arg) => (
+              <div key={arg.name} className="flex flex-col text-[0.6875rem] leading-3.5">
+                <span className="text-on-surface font-mono font-medium">
+                  {arg.name}
+                  {arg.required && <span className="text-error ml-0.5 font-bold">*</span>}
+                </span>
+                {arg.description && (
+                  <span className="text-on-surface-muted">{arg.description}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolItem({ tool }: { tool: McpTool }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpand = useCallback(() => {
+    setExpanded((prev) => !prev);
+  }, []);
+
+  const hasSchema = !!tool.inputSchema?.properties;
+
+  return (
+    <div className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col rounded-[var(--radius-sm)] border p-2.5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Wrench className="text-primary size-3.5 shrink-0" />
+          <span className="text-on-surface truncate font-mono text-xs font-semibold">
+            {tool.name}
+          </span>
+        </div>
+
+        {hasSchema && (
+          <button
+            type="button"
+            onClick={toggleExpand}
+            title={expanded ? "Hide input schema" : "Show input schema"}
+            className="state-layer text-on-surface-variant hover:bg-on-surface/5 flex size-5 cursor-pointer items-center justify-center rounded-full transition-colors"
+          >
+            {expanded ? (
+              <ChevronDown className="size-3.5" />
+            ) : (
+              <ChevronRight className="size-3.5" />
+            )}
+          </button>
+        )}
+      </div>
+
+      {tool.description && (
+        <p className="text-on-surface-variant mt-1 text-[0.75rem] leading-4">{tool.description}</p>
+      )}
+
+      {expanded && tool.inputSchema && (
+        <div className="border-on-surface/5 mt-2 border-t pt-2">
+          <span className="text-on-surface-muted block pb-1 text-[0.625rem] font-bold tracking-wider uppercase">
+            Input Parameters (JSON Schema)
+          </span>
+          <pre className="bg-on-surface/[0.03] border-on-surface/10 text-on-surface-variant overflow-x-auto rounded-[var(--radius-xs)] border p-1.5 font-mono text-[0.6875rem] leading-4">
+            {JSON.stringify(tool.inputSchema, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -51,7 +51,11 @@ type PromptsResponse = { prompts?: Prompt[]; error?: string };
  * Renders the MCP Server Registry panel listing all registered tools and prompts.
  */
 export function RegistryPanel({ onExecutePrompt, isBusy }: RegistryPanelProps) {
-  const { data: toolsData, isLoading: isToolsLoading } = useSWR<ToolsResponse>(
+  const {
+    data: toolsData,
+    isLoading: isToolsLoading,
+    error: toolsError,
+  } = useSWR<ToolsResponse>(
     "/api/tools",
     async (url: string) => {
       const res = await authAwareFetch(url);
@@ -61,7 +65,11 @@ export function RegistryPanel({ onExecutePrompt, isBusy }: RegistryPanelProps) {
     { revalidateOnFocus: false },
   );
 
-  const { data: promptsData, isLoading: isPromptsLoading } = useSWR<PromptsResponse>(
+  const {
+    data: promptsData,
+    isLoading: isPromptsLoading,
+    error: promptsError,
+  } = useSWR<PromptsResponse>(
     "/api/prompts",
     async (url: string) => {
       const res = await authAwareFetch(url);
@@ -73,6 +81,20 @@ export function RegistryPanel({ onExecutePrompt, isBusy }: RegistryPanelProps) {
 
   const tools = toolsData?.tools ?? [];
   const prompts = promptsData?.prompts ?? [];
+
+  if (toolsError || promptsError) {
+    return (
+      <div className="flex flex-col gap-3 px-4 py-6">
+        <div className="bg-error-light border-error/15 text-error flex flex-col gap-2 rounded-[var(--radius-sm)] border p-3.5 text-xs">
+          <h3 className="text-sm font-semibold">Failed to connect to MCP Server</h3>
+          <p className="leading-5">
+            Could not fetch tools or prompts. Ensure your MCP server is running and configured
+            correctly in the doctor panel.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (isToolsLoading || isPromptsLoading) {
     return (

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -195,32 +195,18 @@ function PromptItem({
   );
 }
 
-function getTruncatedDescription(description?: string, limit = 120): string {
-  if (!description) return "";
-  const sentences = description.split(/(?<=[.!?])\s+/);
-  const firstSentence = sentences[0] || "";
-
-  if (firstSentence.length <= limit) {
-    return firstSentence;
-  }
-  return firstSentence.slice(0, limit).trim() + "...";
-}
-
 function ToolItem({ tool }: { tool: McpTool }) {
   const [expanded, setExpanded] = useState(false);
-  const [descExpanded, setDescExpanded] = useState(false);
 
   const toggleExpand = useCallback(() => {
     setExpanded((prev) => !prev);
   }, []);
 
-  const hasSchema = !!tool.inputSchema?.properties;
-  const truncatedDesc = getTruncatedDescription(tool.description);
-  const isDescriptionTruncated = tool.description && tool.description !== truncatedDesc;
+  const hasDetails = !!(tool.description || tool.inputSchema?.properties);
 
   return (
     <div className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col rounded-[var(--radius-sm)] border p-2.5">
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-1.5">
           <Wrench className="text-primary size-3.5 shrink-0" />
           <span className="text-on-surface truncate font-mono text-xs font-semibold">
@@ -228,11 +214,11 @@ function ToolItem({ tool }: { tool: McpTool }) {
           </span>
         </div>
 
-        {hasSchema && (
+        {hasDetails && (
           <button
             type="button"
             onClick={toggleExpand}
-            title={expanded ? "Hide input schema" : "Show input schema"}
+            title={expanded ? "Hide details" : "Show details"}
             className="state-layer text-on-surface-variant hover:bg-on-surface/5 flex size-5 cursor-pointer items-center justify-center rounded-full transition-colors"
           >
             {expanded ? (
@@ -244,59 +230,54 @@ function ToolItem({ tool }: { tool: McpTool }) {
         )}
       </div>
 
-      {tool.description && (
-        <p className="text-on-surface-variant mt-1 text-[0.75rem] leading-4 text-pretty">
-          {descExpanded ? tool.description : truncatedDesc}
-          {isDescriptionTruncated && (
-            <button
-              type="button"
-              onClick={() => setDescExpanded((prev) => !prev)}
-              className="text-primary ml-1 cursor-pointer font-medium hover:underline"
-            >
-              {descExpanded ? "less" : "more"}
-            </button>
+      {expanded && (
+        <div className="animate-fade-in flex flex-col gap-2.5">
+          {tool.description && (
+            <p className="text-on-surface-variant mt-2 text-[0.75rem] leading-4 text-pretty">
+              {tool.description}
+            </p>
           )}
-        </p>
-      )}
 
-      {expanded && tool.inputSchema?.properties && (
-        <div className="border-on-surface/5 mt-2 border-t pt-2">
-          <span className="text-on-surface-muted block pb-1.5 text-[0.625rem] font-bold tracking-wider uppercase">
-            Input Parameters
-          </span>
-          <ul className="flex flex-col gap-2">
-            {Object.entries(tool.inputSchema.properties).map(([key, prop]) => {
-              const isRequired = tool.inputSchema?.required?.includes(key);
-              const propVal = prop as { type?: string; description?: string };
-              const propType = propVal.type || "any";
-              const propDesc = propVal.description;
+          {tool.inputSchema?.properties && (
+            <div className="border-on-surface/5 mt-1 border-t pt-2.5">
+              <span className="text-on-surface-muted block pb-1.5 text-[0.625rem] font-bold tracking-wider uppercase">
+                Input Parameters
+              </span>
+              <ul className="flex flex-col gap-2">
+                {Object.entries(tool.inputSchema.properties).map(([key, prop]) => {
+                  const isRequired = tool.inputSchema?.required?.includes(key);
+                  const propVal = prop as { type?: string; description?: string };
+                  const propType = propVal.type || "any";
+                  const propDesc = propVal.description;
 
-              return (
-                <li
-                  key={key}
-                  className="border-on-surface/5 flex flex-col gap-0.5 border-l-2 pl-2.5 leading-normal"
-                >
-                  <div className="flex items-baseline gap-1.5 font-mono text-[0.6875rem]">
-                    <span className="text-on-surface font-semibold">{key}</span>
-                    <span
-                      className={`text-[0.625rem] tracking-wider uppercase ${
-                        isRequired
-                          ? "text-on-surface-variant/50 font-bold"
-                          : "text-on-surface-variant/30 font-medium"
-                      }`}
+                  return (
+                    <li
+                      key={key}
+                      className="border-on-surface/5 flex flex-col gap-0.5 border-l-2 pl-2.5 leading-normal"
                     >
-                      ({propType} · {isRequired ? "required" : "optional"})
-                    </span>
-                  </div>
-                  {propDesc && (
-                    <span className="text-on-surface-variant text-[0.6875rem] leading-3.5 text-pretty">
-                      {propDesc}
-                    </span>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
+                      <div className="flex items-baseline gap-1.5 font-mono text-[0.6875rem]">
+                        <span className="text-on-surface font-semibold">{key}</span>
+                        <span
+                          className={`text-[0.625rem] tracking-wider uppercase ${
+                            isRequired
+                              ? "text-on-surface-variant/50 font-bold"
+                              : "text-on-surface-variant/30 font-medium"
+                          }`}
+                        >
+                          ({propType} · {isRequired ? "required" : "optional"})
+                        </span>
+                      </div>
+                      {propDesc && (
+                        <span className="text-on-surface-variant text-[0.6875rem] leading-3.5 text-pretty">
+                          {propDesc}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -234,14 +234,39 @@ function ToolItem({ tool }: { tool: McpTool }) {
         <p className="text-on-surface-variant mt-1 text-[0.75rem] leading-4">{tool.description}</p>
       )}
 
-      {expanded && tool.inputSchema && (
+      {expanded && tool.inputSchema?.properties && (
         <div className="border-on-surface/5 mt-2 border-t pt-2">
-          <span className="text-on-surface-muted block pb-1 text-[0.625rem] font-bold tracking-wider uppercase">
-            Input Parameters (JSON Schema)
+          <span className="text-on-surface-muted block pb-1.5 text-[0.625rem] font-bold tracking-wider uppercase">
+            Input Parameters
           </span>
-          <pre className="bg-on-surface/[0.03] border-on-surface/10 text-on-surface-variant overflow-x-auto rounded-[var(--radius-xs)] border p-1.5 font-mono text-[0.6875rem] leading-4">
-            {JSON.stringify(tool.inputSchema, null, 2)}
-          </pre>
+          <ul className="flex flex-col gap-2">
+            {Object.entries(tool.inputSchema.properties).map(([key, prop]) => {
+              const isRequired = tool.inputSchema?.required?.includes(key);
+              const propVal = prop as { type?: string; description?: string };
+              const propType = propVal.type || "any";
+              const propDesc = propVal.description;
+
+              return (
+                <li
+                  key={key}
+                  className="border-on-surface/5 flex flex-col gap-0.5 border-l-2 pl-2.5 leading-normal"
+                >
+                  <div className="flex items-center gap-1.5 font-mono text-[0.6875rem]">
+                    <span className="text-on-surface font-semibold">{key}</span>
+                    {isRequired && <span className="text-error leading-none font-bold">*</span>}
+                    <span className="text-on-surface-variant/50 text-[0.625rem] font-bold tracking-wider uppercase">
+                      ({propType})
+                    </span>
+                  </div>
+                  {propDesc && (
+                    <span className="text-on-surface-variant text-[0.6875rem] leading-3.5 text-pretty">
+                      {propDesc}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
         </div>
       )}
     </div>

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -47,6 +47,9 @@ type RegistryPanelProps = {
 type ToolsResponse = { tools?: McpTool[] };
 type PromptsResponse = { prompts?: Prompt[]; error?: string };
 
+/**
+ * Renders the MCP Server Registry panel listing all registered tools and prompts.
+ */
 export function RegistryPanel({ onExecutePrompt, isBusy }: RegistryPanelProps) {
   const { data: toolsData, isLoading: isToolsLoading } = useSWR<ToolsResponse>(
     "/api/tools",

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -83,6 +83,13 @@ export function RegistryPanel({ onExecutePrompt, isBusy }: RegistryPanelProps) {
 
   return (
     <div className="flex flex-col gap-6 px-4 py-4">
+      <header className="border-on-surface/5 flex flex-col gap-1 border-b pb-2">
+        <h1 className="text-on-surface text-sm font-semibold">MCP Server Registry</h1>
+        <p className="text-on-surface-variant text-[0.6875rem] leading-4 text-pretty">
+          Connected capabilities, tools, and prompts registered by the MCP server.
+        </p>
+      </header>
+
       {/* Prompts Section */}
       <section aria-label="Available Prompts" className="flex flex-col gap-3">
         <header className="border-on-surface/10 flex items-baseline justify-between border-b pb-1.5">

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -203,9 +203,13 @@ function ToolItem({ tool }: { tool: McpTool }) {
   }, []);
 
   const hasDetails = !!(tool.description || tool.inputSchema?.properties);
+  const firstSentence = tool.description ? tool.description.split(/(?<=[.!?])\s+/)[0] || "" : "";
 
   return (
-    <div className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col rounded-[var(--radius-sm)] border p-2.5">
+    <div
+      title={expanded ? undefined : firstSentence || undefined}
+      className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col rounded-[var(--radius-sm)] border p-2.5"
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-1.5">
           <Wrench className="text-primary size-3.5 shrink-0" />

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -142,53 +142,105 @@ function PromptItem({
   onRun: (prompt: Prompt) => void;
   isBusy: boolean;
 }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpand = useCallback(() => {
+    setExpanded((prev) => !prev);
+  }, []);
+
   const title = prompt.title || prompt.name.replace(/^[^:]+:/, "");
   const cleanTitle = title.charAt(0).toUpperCase() + title.slice(1);
   const hasRequiredArgs = prompt.arguments?.some((a) => a.required) ?? false;
+  const hasDetails = !!(prompt.description || (prompt.arguments && prompt.arguments.length > 0));
+
+  const firstSentence = prompt.description
+    ? prompt.description.split(/(?<=[.!?])\s+/)[0] || ""
+    : "";
 
   return (
-    <div className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col gap-1 rounded-[var(--radius-sm)] border p-2.5">
-      <div className="flex items-start justify-between gap-2">
+    <div
+      title={expanded ? undefined : firstSentence || undefined}
+      className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col rounded-[var(--radius-sm)] border p-2.5"
+    >
+      <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-1.5">
           <Terminal className="text-primary size-3.5 shrink-0" />
-          <span className="text-on-surface truncate text-xs font-semibold">{cleanTitle}</span>
+          <span className="text-on-surface truncate font-mono text-xs font-semibold">
+            {cleanTitle}
+          </span>
         </div>
 
-        {!hasRequiredArgs && (
-          <button
-            type="button"
-            onClick={() => onRun(prompt)}
-            disabled={isBusy}
-            title="Execute prompt in chat"
-            className="state-layer text-primary hover:bg-primary/5 flex size-5 cursor-pointer items-center justify-center rounded-full transition-colors disabled:opacity-40"
-          >
-            <ArrowUpRight className="size-3.5" />
-          </button>
-        )}
+        <div className="flex shrink-0 items-center gap-0.5">
+          {!hasRequiredArgs && (
+            <button
+              type="button"
+              onClick={() => onRun(prompt)}
+              disabled={isBusy}
+              title="Execute prompt in chat"
+              className="state-layer text-primary hover:bg-primary/5 flex size-5 cursor-pointer items-center justify-center rounded-full transition-colors disabled:opacity-40"
+            >
+              <ArrowUpRight className="size-3.5" />
+            </button>
+          )}
+
+          {hasDetails && (
+            <button
+              type="button"
+              onClick={toggleExpand}
+              title={expanded ? "Hide details" : "Show details"}
+              className="state-layer text-on-surface-variant hover:bg-on-surface/5 flex size-5 cursor-pointer items-center justify-center rounded-full transition-colors"
+            >
+              {expanded ? (
+                <ChevronDown className="size-3.5" />
+              ) : (
+                <ChevronRight className="size-3.5" />
+              )}
+            </button>
+          )}
+        </div>
       </div>
 
-      {prompt.description && (
-        <p className="text-on-surface-variant text-[0.75rem] leading-4">{prompt.description}</p>
-      )}
+      {expanded && (
+        <div className="animate-fade-in flex flex-col gap-2.5">
+          {prompt.description && (
+            <p className="text-on-surface-variant mt-2 text-[0.75rem] leading-4 text-pretty">
+              {prompt.description}
+            </p>
+          )}
 
-      {prompt.arguments && prompt.arguments.length > 0 && (
-        <div className="border-on-surface/5 mt-1.5 flex flex-col gap-1 border-t pt-1.5">
-          <span className="text-on-surface-muted text-[0.625rem] font-bold tracking-wider uppercase">
-            Arguments
-          </span>
-          <div className="flex flex-col gap-1">
-            {prompt.arguments.map((arg) => (
-              <div key={arg.name} className="flex flex-col text-[0.6875rem] leading-3.5">
-                <span className="text-on-surface font-mono font-medium">
-                  {arg.name}
-                  {arg.required && <span className="text-error ml-0.5 font-bold">*</span>}
-                </span>
-                {arg.description && (
-                  <span className="text-on-surface-muted">{arg.description}</span>
-                )}
-              </div>
-            ))}
-          </div>
+          {prompt.arguments && prompt.arguments.length > 0 && (
+            <div className="border-on-surface/5 mt-1 border-t pt-2.5">
+              <span className="text-on-surface-muted block pb-1.5 text-[0.625rem] font-bold tracking-wider uppercase">
+                Expected Arguments
+              </span>
+              <ul className="flex flex-col gap-2">
+                {prompt.arguments.map((arg) => (
+                  <li
+                    key={arg.name}
+                    className="border-on-surface/5 flex flex-col gap-0.5 border-l-2 pl-2.5 leading-normal"
+                  >
+                    <div className="flex items-baseline gap-1.5 font-mono text-[0.6875rem]">
+                      <span className="text-on-surface font-semibold">{arg.name}</span>
+                      <span
+                        className={`text-[0.625rem] tracking-wider uppercase ${
+                          arg.required
+                            ? "text-on-surface-variant/50 font-bold"
+                            : "text-on-surface-variant/30 font-medium"
+                        }`}
+                      >
+                        ({arg.required ? "required" : "optional"})
+                      </span>
+                    </div>
+                    {arg.description && (
+                      <span className="text-on-surface-variant text-[0.6875rem] leading-3.5 text-pretty">
+                        {arg.description}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -208,6 +208,7 @@ function getTruncatedDescription(description?: string, limit = 120): string {
 
 function ToolItem({ tool }: { tool: McpTool }) {
   const [expanded, setExpanded] = useState(false);
+  const [descExpanded, setDescExpanded] = useState(false);
 
   const toggleExpand = useCallback(() => {
     setExpanded((prev) => !prev);
@@ -215,6 +216,7 @@ function ToolItem({ tool }: { tool: McpTool }) {
 
   const hasSchema = !!tool.inputSchema?.properties;
   const truncatedDesc = getTruncatedDescription(tool.description);
+  const isDescriptionTruncated = tool.description && tool.description !== truncatedDesc;
 
   return (
     <div className="bg-on-surface/[0.02] border-on-surface/5 flex flex-col rounded-[var(--radius-sm)] border p-2.5">
@@ -243,8 +245,17 @@ function ToolItem({ tool }: { tool: McpTool }) {
       </div>
 
       {tool.description && (
-        <p className="text-on-surface-variant animate-fade-in mt-1 text-[0.75rem] leading-4 text-pretty">
-          {expanded ? tool.description : truncatedDesc}
+        <p className="text-on-surface-variant mt-1 text-[0.75rem] leading-4 text-pretty">
+          {descExpanded ? tool.description : truncatedDesc}
+          {isDescriptionTruncated && (
+            <button
+              type="button"
+              onClick={() => setDescExpanded((prev) => !prev)}
+              className="text-primary ml-1 cursor-pointer font-medium hover:underline"
+            >
+              {descExpanded ? "less" : "more"}
+            </button>
+          )}
         </p>
       )}
 

--- a/mcp-examples/pocket-cep/src/components/registry-panel.tsx
+++ b/mcp-examples/pocket-cep/src/components/registry-panel.tsx
@@ -251,11 +251,16 @@ function ToolItem({ tool }: { tool: McpTool }) {
                   key={key}
                   className="border-on-surface/5 flex flex-col gap-0.5 border-l-2 pl-2.5 leading-normal"
                 >
-                  <div className="flex items-center gap-1.5 font-mono text-[0.6875rem]">
+                  <div className="flex items-baseline gap-1.5 font-mono text-[0.6875rem]">
                     <span className="text-on-surface font-semibold">{key}</span>
-                    {isRequired && <span className="text-error leading-none font-bold">*</span>}
-                    <span className="text-on-surface-variant/50 text-[0.625rem] font-bold tracking-wider uppercase">
-                      ({propType})
+                    <span
+                      className={`text-[0.625rem] tracking-wider uppercase ${
+                        isRequired
+                          ? "text-on-surface-variant/50 font-bold"
+                          : "text-on-surface-variant/30 font-medium"
+                      }`}
+                    >
+                      ({propType} · {isRequired ? "required" : "optional"})
                     </span>
                   </div>
                   {propDesc && (


### PR DESCRIPTION
## Motivation
In PocketCEP, administrators need visibility into the capabilities and tools injected into the AI agent's context window. They need a catalog showing what prompts (conversation templates) and tools are registered by the connected MCP server. Furthermore, they need a way to easily trigger these prompts (such as running environment health checks) directly from the sidebar UI.

This PR introduces the **MCP Server Registry** sidebar panel to display connected tools, input parameter schemas, and conversation prompts.

*Note: This PR is stacked on top of #70.*

## Main Changes
*   **Sidebar Tab list Unification**:
    *   Simplified the sidebar tab switches to a clean, icons-only layout (`Activity` -> Graph, `MCP Inspector` -> Wrench, `MCP Server Registry` -> BookOpen).
    *   Added browser-native hover tooltips (`title`) and screen reader labels (`aria-label`) to keep the rail spacious while remaining fully accessible.
    *   Repositioned the active tool execution count badge to an absolute top-right overlay on the Wrench icon.
*   **Server Registry Panel (`RegistryPanel`)**:
    *   Lists tools and prompts fetched from `/api/tools` and `/api/prompts`.
    *   Includes a main header explicitly labeling the panel as the **MCP Server Registry** and explaining its purpose.
    *   Displays cards in a dense, title-only collapsed state for maximum scanability (important since the server lists ~30+ tools).
    *   Hovering over a collapsed card displays the first sentence of its description in a browser tooltip.
    *   Expanding a card reveals its full description and a nested parameters/arguments directory tree.
*   **Directory-Style Parameters & Arguments Tree**:
    *   Renders parameter names, types, and descriptions in a monospace vertical list with left-border nesting styling (`border-l-2 pl-2.5`).
    *   Replaced distracting red asterisks (`*`) with clean, low-contrast text tags: `(string · required)` in bold and `(integer · optional)` in light, muted font weights.
*   **Sidebar-to-Chat execution pipeline**:
    *   Exposed prompt execute triggers (`ArrowUpRight`) on the prompt cards. Clicking a trigger sets a `pendingPrompt` state.
    *   Plumbed this state into `ChatPanel`, which runs it in the active conversation chat. Used `setTimeout(..., 0)` to decouple execution from React's hydration cycles and prevent render warnings.
*   **Integration Tests**:
    *   Created `mcp-registry.test.ts` to test tools lists, prompts lists, and prompt expansion endpoints.

## Design Decisions
*   **Collapsed-by-Default Scanning**: Because the connected server lists many tools, showing descriptions by default led to massive vertical scrolling. Restricting the default collapsed view to the tool name makes scanning extremely fast.
*   **Unifying Parameters and Arguments Layout**: Prompts argument lists and tools parameter lists use the same directory tree structure and text-based required/optional tags, creating a predictable, unified visual design.
*   **Vanilla Browser Tooltips**: Leveraging the native `title` attribute for descriptions on hover provides instant clarity without importing heavy popover libraries or cluttering the DOM.

TAG=agy
CONV=e44d9a07-4087-4b76-931d-c6adea10f53a
