### PR TITLE
Resolve posture diagnostics warning and middleware cache pollution

### DIFF
--- a/mcp-examples/pocket-cep/src/app/api/insights/posture-alerts/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/insights/posture-alerts/route.ts
@@ -137,6 +137,14 @@ export async function POST(_request: Request) {
         {},
         accessToken,
       );
+
+      const trText =
+        typeof customerIdResult.content === "string"
+          ? customerIdResult.content
+          : JSON.stringify(customerIdResult.content);
+      const authErr = toAuthError(trText, "mcp-tool") ?? toAuthError(customerIdResult, "mcp-tool");
+      if (authErr) throw authErr;
+
       if (customerIdResult && !customerIdResult.isError) {
         const data = customerIdResult.structuredContent as { customerId?: string; id?: string };
         const resolvedId = data?.customerId || data?.id;
@@ -148,6 +156,7 @@ export async function POST(_request: Request) {
         console.warn("[posture] get_customer_id tool returned error:", customerIdResult);
       }
     } catch (e) {
+      if (isAuthError(e)) throw e;
       console.error("[posture] Failed to call get_customer_id tool:", e);
     }
   }

--- a/mcp-examples/pocket-cep/src/app/api/insights/posture-alerts/route.ts
+++ b/mcp-examples/pocket-cep/src/app/api/insights/posture-alerts/route.ts
@@ -122,10 +122,35 @@ export async function POST(_request: Request) {
   }
 
   const config = getEnv();
-  const [accessToken, customerId] = await Promise.all([
+  const [accessToken, envCustomerId] = await Promise.all([
     getGoogleAccessToken(),
     getActiveCustomerId(),
   ]);
+
+  let customerId = envCustomerId;
+  if (!customerId && accessToken) {
+    try {
+      console.log("[posture] customerId is empty. Resolving via get_customer_id tool...");
+      const customerIdResult = await callMcpTool(
+        config.MCP_SERVER_URL,
+        "get_customer_id",
+        {},
+        accessToken,
+      );
+      if (customerIdResult && !customerIdResult.isError) {
+        const data = customerIdResult.structuredContent as { customerId?: string; id?: string };
+        const resolvedId = data?.customerId || data?.id;
+        if (resolvedId) {
+          customerId = resolvedId;
+          console.log(`[posture] Successfully resolved customerId: ${customerId}`);
+        }
+      } else {
+        console.warn("[posture] get_customer_id tool returned error:", customerIdResult);
+      }
+    } catch (e) {
+      console.error("[posture] Failed to call get_customer_id tool:", e);
+    }
+  }
 
   try {
     const callerKey = buildCallerCacheKey(config.MCP_SERVER_URL, accessToken, customerId);

--- a/mcp-examples/pocket-cep/src/proxy.ts
+++ b/mcp-examples/pocket-cep/src/proxy.ts
@@ -79,7 +79,10 @@ export async function proxy(request: NextRequest) {
     if (isEnvValidationError(error)) {
       return new NextResponse(renderEnvErrorHtml(error.issues), {
         status: 500,
-        headers: { "content-type": "text/html; charset=utf-8" },
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          "cache-control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+        },
       });
     }
     throw error;
@@ -125,7 +128,10 @@ export async function proxy(request: NextRequest) {
     if (!mcpOk) {
       return new NextResponse(renderMcpUnreachableHtml(env.MCP_SERVER_URL), {
         status: 503,
-        headers: { "content-type": "text/html; charset=utf-8" },
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          "cache-control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+        },
       });
     }
   }


### PR DESCRIPTION
Resolve posture diagnostics warning and middleware cache pollution

**Motivation**
During Google OAuth authentication (user_oauth mode), the Chrome Enterprise Premium posture checklist widget was failing to load, displaying the "Unable to load posture diagnostics" warning. 

**Root Cause**
- The `diagnose_environment` MCP tool expects a Workspace `customerId`. When in oauth mode, this config is omitted (defaults to empty string), which causes the tool to make parallel requests using an undefined customer ID. The Admin SDK and Chrome Management API calls throw 403 / validation errors, crashing the entire diagnose tool.
- When the health probe failed, the Next.js middleware returned a 503 Service Unavailable page without disabling caching, which caused the browser to cache the error screen even after containers booted successfully.

**Main Changes**
- Route handler: In `src/app/api/insights/posture-alerts/route.ts`, added fallback logic to call the `get_customer_id` MCP tool dynamically using the user's OAuth access token if the customer ID is empty.
- Middleware: Added `Cache-Control` headers (`no-store, no-cache, must-revalidate, proxy-revalidate`) to both 500 (env error) and 503 (MCP unreachable) responses in `src/proxy.ts` to prevent browser caching of failure screens.
