### PR TITLE
fix(auth): enable trustedProxyHeaders for GCLB and configure account cookie storage

### DIFF
--- a/mcp-examples/pocket-cep/.env
+++ b/mcp-examples/pocket-cep/.env
@@ -33,7 +33,7 @@ AUTH_MODE=service_account
 # URL of the Chrome Enterprise Premium MCP server running in HTTP mode.
 # Start it with: npm run dev:full (starts both app and MCP server)
 # Or manually:   GCP_STDIO=false PORT=4000 npx @google/chrome-enterprise-premium-mcp@latest
-MCP_SERVER_URL=http://localhost:4000/mcp
+MCP_SERVER_URL=http://127.0.0.1:4000/mcp
 
 
 

--- a/mcp-examples/pocket-cep/.gitignore
+++ b/mcp-examples/pocket-cep/.gitignore
@@ -43,3 +43,10 @@ sa-key.json
 *.tsbuildinfo
 next-env.d.ts
 test-results/
+
+# Corp Run / Google Internal Deployment (ignored for public GitHub security)
+Dockerfile.frontend
+Dockerfile.mcp
+scripts/build-and-push.sh
+scripts/deploy-preflight.sh
+scripts/provision-secrets.sh

--- a/mcp-examples/pocket-cep/.gitignore
+++ b/mcp-examples/pocket-cep/.gitignore
@@ -43,10 +43,3 @@ sa-key.json
 *.tsbuildinfo
 next-env.d.ts
 test-results/
-
-# Corp Run / Google Internal Deployment (ignored for public GitHub security)
-Dockerfile.frontend
-Dockerfile.mcp
-scripts/build-and-push.sh
-scripts/deploy-preflight.sh
-scripts/provision-secrets.sh

--- a/mcp-examples/pocket-cep/src/app/page.tsx
+++ b/mcp-examples/pocket-cep/src/app/page.tsx
@@ -23,6 +23,8 @@ import { getEnv } from "@/lib/env";
  * - In service_account mode, redirects to /sa-setup to configure target Customer ID and checklists.
  * - In user_oauth mode, displays standard Google-style centered sign-in card.
  */
+export const dynamic = "force-dynamic";
+
 export default async function LandingPage() {
   const env = getEnv();
   if (env.AUTH_MODE === "service_account") {

--- a/mcp-examples/pocket-cep/src/lib/access-token.ts
+++ b/mcp-examples/pocket-cep/src/lib/access-token.ts
@@ -269,8 +269,7 @@ export async function getGoogleAccessToken(options?: {
       body: {
         providerId: "google",
         useAccountCookie: true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any,
+      } as { providerId: string; useAccountCookie?: boolean },
       headers: await headers(),
     });
 

--- a/mcp-examples/pocket-cep/src/lib/access-token.ts
+++ b/mcp-examples/pocket-cep/src/lib/access-token.ts
@@ -266,7 +266,11 @@ export async function getGoogleAccessToken(options?: {
   try {
     const auth = getAuth();
     const tokenResult = await auth.api.getAccessToken({
-      body: { providerId: "google" },
+      body: {
+        providerId: "google",
+        useAccountCookie: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
       headers: await headers(),
     });
 

--- a/mcp-examples/pocket-cep/src/lib/auth.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth.ts
@@ -39,6 +39,12 @@ function createAuth() {
   return betterAuth({
     secret: config.BETTER_AUTH_SECRET,
     baseURL: config.BETTER_AUTH_URL,
+    account: {
+      storeAccountCookie: true,
+    },
+    advanced: {
+      trustedProxyHeaders: true,
+    },
 
     /**
      * In service_account mode, no social providers are registered —
@@ -51,7 +57,7 @@ function createAuth() {
             clientId: config.GOOGLE_CLIENT_ID,
             clientSecret: config.GOOGLE_CLIENT_SECRET,
             scope: ADMIN_SCOPES,
-            prompt: "consent",
+            prompt: "select_account",
             accessType: "offline",
           },
         },

--- a/mcp-examples/pocket-cep/src/lib/auth.ts
+++ b/mcp-examples/pocket-cep/src/lib/auth.ts
@@ -57,7 +57,7 @@ function createAuth() {
             clientId: config.GOOGLE_CLIENT_ID,
             clientSecret: config.GOOGLE_CLIENT_SECRET,
             scope: ADMIN_SCOPES,
-            prompt: "select_account",
+            prompt: "consent select_account",
             accessType: "offline",
           },
         },

--- a/mcp-examples/pocket-cep/src/lib/errors.ts
+++ b/mcp-examples/pocket-cep/src/lib/errors.ts
@@ -16,5 +16,12 @@
  * classification later (single point of change).
  */
 export function getErrorMessage(error: unknown, fallback = "Unknown error"): string {
-  return error instanceof Error ? error.message : fallback;
+  if (error instanceof Error) {
+    let causeText = "";
+    if (error.cause) {
+      causeText = ` (cause: ${error.cause instanceof Error ? error.cause.message : String(error.cause)})`;
+    }
+    return `${error.message}${causeText}`;
+  }
+  return fallback;
 }


### PR DESCRIPTION
### Rationale
When running Pocket CEP behind a Google Cloud Load Balancer (GCLB) in Cloud Run, HTTPS termination happens at the load balancer. BetterAuth requires `trustedProxyHeaders: true` to process incoming `X-Forwarded-Proto` headers and properly set secure HTTPS session cookies without redirect loops.

### Main Changes
- Enable `advanced.trustedProxyHeaders: true` and `account.storeAccountCookie: true` in BetterAuth configuration (`src/lib/auth.ts`).
- Pass `useAccountCookie: true` in `getGoogleAccessToken` (`src/lib/access-token.ts`).
- Extract nested error cause messages in `getErrorMessage` (`src/lib/errors.ts`).
- Update local `MCP_SERVER_URL` loopback default to `127.0.0.1` (`.env`).