### PR TITLE
feat(next): enforce app-wide dynamic rendering in root layout

### DIFF
--- a/mcp-examples/pocket-cep/src/app/dashboard/page.tsx
+++ b/mcp-examples/pocket-cep/src/app/dashboard/page.tsx
@@ -4,8 +4,6 @@
 
 import { DashboardClient } from "./dashboard-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function DashboardPage() {
   return <DashboardClient />;
 }

--- a/mcp-examples/pocket-cep/src/app/layout.tsx
+++ b/mcp-examples/pocket-cep/src/app/layout.tsx
@@ -43,6 +43,13 @@ export const metadata: Metadata = {
     "Investigate user activity and chat with an AI-powered admin assistant.",
 };
 
+/**
+ * Enforce dynamic server rendering app-wide.
+ * Pocket CEP is an authenticated admin portal where all routes depend on runtime
+ * environment variables (AUTH_MODE), cookies, and sessions injected at container startup.
+ */
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({
   children,
 }: Readonly<{


### PR DESCRIPTION
### Summary
This PR enforces `export const dynamic = "force-dynamic"` globally at the root layout ([src/app/layout.tsx](file:///usr/local/google/home/dylanklein/ChromeBrowserEnterprise/mcp-examples/pocket-cep/src/app/layout.tsx)) level.

### Why this is needed
Pocket CEP is an authenticated admin portal where all page routes depend on runtime environment variables (`AUTH_MODE`), cookies, and sessions injected at container startup (Cloud Run / Docker).

In Next.js App Router, Route Segment Configs cascade downward from parent layouts to all child pages. Moving `force-dynamic` to [src/app/layout.tsx](file:///usr/local/google/home/dylanklein/ChromeBrowserEnterprise/mcp-examples/pocket-cep/src/app/layout.tsx) guarantees:
1. **100% Automatic Coverage**: All present and future page routes are rendered dynamically at request time without risk of engineers forgetting to add route-level exports to new `page.tsx` files.
2. **Eliminates Container Pre-Rendering Bugs**: Prevents `npm run build` from compiling static HTML redirect loops on Cloud Run.
3. **Clean Code Hygiene**: Consolidates route rendering strategy into a single documented source of truth.